### PR TITLE
fix: corrected error in update_version_check.py

### DIFF
--- a/src/osdag/update_version_check.py
+++ b/src/osdag/update_version_check.py
@@ -9,22 +9,19 @@ class Update():
     def __init__(self):
         super().__init__()
         self.old_version=self.get_current_version()
-        # msg = self.notifi()
 
     def notifi(self):
         try:
-            url = "https://raw.githubusercontent.com/osdag-admin/Osdag/master/README.md"
+            url = "https://raw.githubusercontent.com/osdag-admin/Osdag/master/src/osdag/_version.py"
             file = urllib.request.urlopen(url)
             version = 'not found'
             for line in file:
                 decoded_line = line.decode("utf-8")
-                match = re.search(r'Download the latest release version (\S+)', decoded_line)
+                match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", decoded_line, re.M)
                 if match:
                     version = match.group(1)
                     version = version.split("<")[0]
                     break
-            # decoded_line = line.decode("utf-8")
-            # new_version = decoded_line.split("=")[1]
             if version != self.old_version:
                 msg = 'Current version: '+ self.old_version+'<br>'+'Latest version '+ str(version)+'<br>'+\
                       'Update will be available <a href=\"https://osdag.fossee.in/resources/downloads\"> here <a/>'


### PR DESCRIPTION
Instead of using the `Readme.md` file we could directly use the `__version.py` of the repository, and perform a regex search to fetch the latest version.

Changed the `url` of point to `__version.py` file.
Changed the regex to match with `version` in `__version.py` file

Closes #364 