### PR TITLE
Add osdag.cli module for running modules directly from input files(*.osi)

### DIFF
--- a/src/osdag/cli.py
+++ b/src/osdag/cli.py
@@ -1,0 +1,63 @@
+from osdag.design_type.connection.fin_plate_connection import FinPlateConnection
+from osdag.design_type.connection.cleat_angle_connection import CleatAngleConnection
+from osdag.design_type.connection.seated_angle_connection import SeatedAngleConnection
+from osdag.design_type.connection.end_plate_connection import EndPlateConnection
+from osdag.design_type.connection.base_plate_connection import BasePlateConnection
+from osdag.design_type.connection.beam_cover_plate import BeamCoverPlate
+from osdag.design_type.connection.beam_cover_plate_weld import BeamCoverPlateWeld
+from osdag.design_type.connection.column_cover_plate_weld import ColumnCoverPlateWeld
+from osdag.design_type.tension_member.tension_bolted import Tension_bolted
+from osdag.design_type.tension_member.tension_welded import Tension_welded
+from osdag.design_type.connection.beam_beam_end_plate_splice import BeamBeamEndPlateSplice
+from osdag.design_type.connection.beam_column_end_plate import BeamColumnEndPlate
+from osdag.design_type.connection.column_cover_plate import ColumnCoverPlate
+from osdag.design_type.connection.column_end_plate import ColumnEndPlate
+from osdag.design_type.compression_member.compression import Compression
+from osdag.design_type.main import Main
+from osdag.Common import TYPE_TEXTBOX, TYPE_OUT_BUTTON
+from osdag.Common import (
+    # Shear Connection
+    KEY_DISP_FINPLATE,
+    KEY_DISP_ENDPLATE,
+    KEY_DISP_CLEATANGLE,
+    KEY_DISP_SEATED_ANGLE,
+
+    # Base Plate Connection
+    KEY_DISP_BASE_PLATE,
+
+    # Moment Connection
+    KEY_DISP_BEAMCOVERPLATE,
+    KEY_DISP_COLUMNCOVERPLATE,
+    KEY_DISP_BEAMCOVERPLATEWELD,
+    KEY_DISP_COLUMNCOVERPLATEWELD,
+    KEY_DISP_BB_EP_SPLICE,
+    KEY_DISP_COLUMNENDPLATE,
+    KEY_DISP_BCENDPLATE,
+
+    # Tension Member
+    KEY_DISP_TENSION_BOLTED,
+    KEY_DISP_TENSION_WELDED,
+
+    # Compression Member
+    KEY_DISP_COMPRESSION
+
+)
+
+
+available_modules = {
+    KEY_DISP_BASE_PLATE:BasePlateConnection, 
+    KEY_DISP_BEAMCOVERPLATE:BeamCoverPlate, 
+    KEY_DISP_CLEATANGLE:CleatAngleConnection,
+    KEY_DISP_COLUMNCOVERPLATE:ColumnCoverPlate, 
+    KEY_DISP_COLUMNENDPLATE:ColumnEndPlate, 
+    KEY_DISP_ENDPLATE:EndPlateConnection,
+    KEY_DISP_FINPLATE:FinPlateConnection, 
+    KEY_DISP_SEATED_ANGLE:SeatedAngleConnection, 
+    KEY_DISP_TENSION_BOLTED:Tension_bolted,
+    KEY_DISP_TENSION_WELDED:Tension_welded, 
+    KEY_DISP_COMPRESSION:Compression, 
+    KEY_DISP_BEAMCOVERPLATEWELD:BeamCoverPlateWeld,
+    KEY_DISP_COLUMNCOVERPLATEWELD:ColumnCoverPlateWeld, 
+    KEY_DISP_BB_EP_SPLICE:BeamBeamEndPlateSplice,
+    KEY_DISP_BCENDPLATE:BeamColumnEndPlate,
+}

--- a/src/osdag/cli.py
+++ b/src/osdag/cli.py
@@ -113,3 +113,56 @@ def _save_to_pdf(module_class:Main, output_file:Path):
         'logger_messages': ''
         }
     module_class.save_design(module_class, popup_summary)
+
+
+
+def run_module(osi_path:Path | str, op_type:str):
+    """Run the module specified in the OSI file located at osi_path."""
+    if isinstance(osi_path, str):
+        osi_path = Path(osi_path)
+
+    filename = osi_path.stem
+    output_folder_path = osi_path.parent / "Outputs"
+    output_folder_path.mkdir(exist_ok=True)
+    design_dict = _get_design_dictionary(osi_path)
+    if design_dict is None:
+        print("File not found.")
+        return None
+    
+    module_name = design_dict.get("Module")
+    if module_name is None:
+        print("Module not specified.")
+        return None
+
+    module_class = available_modules.get(module_name)
+    if module_class is None:
+        print("Not a valid module class.")
+        return None
+    
+    module_class.set_osdaglogger(None)
+    val_errors = module_class.func_for_validation(module_class, design_dict)
+    
+    if (val_errors is None):
+        output_file = output_folder_path / f"{module_class.__name__}/{filename}"
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+
+        if op_type == "save to csv":
+            _save_to_csv(_get_output_dictionary(module_class),str(output_file)+".csv")
+            return True
+        
+        elif op_type == "save to pdf":
+            _save_to_pdf(module_class, output_file)
+            return True
+
+        elif op_type == "output dictionary":
+            return _get_output_dictionary(module_class)
+
+    else:
+        for error in val_errors:
+            print(f"Error: {error}")
+            return None
+
+
+# run_module(r"C:\Users\1hasa\Osdag\TensionBoltedTest4.osi",op_type="save to csv")
+# run_module(r"C:\Users\1hasa\Osdag\TensionBoltedTest4.osi",op_type="save to pdf")
+# print(run_module(r"C:\Users\1hasa\Osdag\TensionBoltedTest4.osi",op_type="output dictionary"))

--- a/src/osdag/cli.py
+++ b/src/osdag/cli.py
@@ -73,3 +73,19 @@ def _get_design_dictionary(osi_path:Path) -> dict | None:
     with open(osi_path, 'r') as file:
         return yaml.safe_load(file)
     
+def _get_output_dictionary(module_class:Main) -> dict:
+    status = module_class.design_status
+    out_list = module_class.output_values(module_class, status)
+    out_dict = {}
+    for option in out_list:
+        if option[0] is not None and option[2] == TYPE_TEXTBOX:
+            out_dict[option[0]] = option[3]
+        if option[2] == TYPE_OUT_BUTTON:
+            tup = option[3]
+            fn = tup[1]
+            for item in fn(module_class, status):
+                lable = item[0]
+                value = item[3]
+                if lable!=None and value!=None:
+                    out_dict[lable] = value
+    return out_dict

--- a/src/osdag/cli.py
+++ b/src/osdag/cli.py
@@ -89,3 +89,27 @@ def _get_output_dictionary(module_class:Main) -> dict:
                 if lable!=None and value!=None:
                     out_dict[lable] = value
     return out_dict
+
+
+def _save_to_csv(output_dictionary:dict, output_file:str):
+    df = pd.DataFrame(output_dictionary.items())
+    df.to_csv(output_file, index=False, header=None)
+
+def _save_to_pdf(module_class:Main, output_file:Path):
+    popup_summary = {
+            'ProfileSummary': {
+            'CompanyName': 'LoremIpsum', 
+            'CompanyLogo': '', 
+            'Group/TeamName': 'LoremIpsum', 
+            'Designer': 'LoremIpsum'
+        }, 
+        'ProjectTitle': 'Fossee', 
+        'Subtitle': '', 
+        'JobNumber': '123', 
+        'AdditionalComments': 'No comments', 
+        'Client': 'LoremIpsum', 
+        'filename': f'{output_file}', 
+        'does_design_exist': True, 
+        'logger_messages': ''
+        }
+    module_class.save_design(module_class, popup_summary)

--- a/src/osdag/cli.py
+++ b/src/osdag/cli.py
@@ -61,3 +61,15 @@ available_modules = {
     KEY_DISP_BB_EP_SPLICE:BeamBeamEndPlateSplice,
     KEY_DISP_BCENDPLATE:BeamColumnEndPlate,
 }
+
+from pathlib import Path
+import yaml
+import pandas as pd
+
+def _get_design_dictionary(osi_path:Path) -> dict | None:
+    """return the design dictionary from an OSI file."""
+    if not osi_path.exists():
+        return None
+    with open(osi_path, 'r') as file:
+        return yaml.safe_load(file)
+    


### PR DESCRIPTION
This pr adds the functionality to run .osi files without explicitly needing to open the modules. 

---
## Description of code - Created cli.py file
```python
available_modules = {
    KEY_DISP_BASE_PLATE:BasePlateConnection, 
    KEY_DISP_BEAMCOVERPLATE:BeamCoverPlate, 
    KEY_DISP_CLEATANGLE:CleatAngleConnection,
    KEY_DISP_COLUMNCOVERPLATE:ColumnCoverPlate, 
    KEY_DISP_COLUMNENDPLATE:ColumnEndPlate, 
    KEY_DISP_ENDPLATE:EndPlateConnection,
    KEY_DISP_FINPLATE:FinPlateConnection, 
    KEY_DISP_SEATED_ANGLE:SeatedAngleConnection, 
    KEY_DISP_TENSION_BOLTED:Tension_bolted,
    KEY_DISP_TENSION_WELDED:Tension_welded, 
    KEY_DISP_COMPRESSION:Compression, 
    KEY_DISP_BEAMCOVERPLATEWELD:BeamCoverPlateWeld,
    KEY_DISP_COLUMNCOVERPLATEWELD:ColumnCoverPlateWeld, 
    KEY_DISP_BB_EP_SPLICE:BeamBeamEndPlateSplice,
    KEY_DISP_BCENDPLATE:BeamColumnEndPlate,
}
```
These are currently available modules in the osdag application. The osi file must correspond to module from one of these modules. In future if there is a new module, it has to be added here as well.

```python
def _get_design_dictionary(osi_path:Path) -> dict | None:
    """return the design dictionary from an OSI file."""

def _get_output_dictionary(module_class:Main) -> dict:
    """return the output dictionary for the design"""

def _save_to_csv(output_dictionary:dict, output_file:str):
    """save the output dictionary to a csv file"""

def _save_to_pdf(module_class:Main, output_file:Path):
    """save the output dictionary to a pdf file"""

def run_module(osi_path:Path | str, op_type:str) -> bool | dict | None:
    """Run the module specified in the OSI file located at osi_path."""

```

The cli utility has to be integrated in the code 