### PR TITLE
fix: PSO window behavior, Customized thickness crash, and debug flag in PG module

### DIFF
--- a/src/osdag_core/design_type/plate_girder/core/plate_girder.py
+++ b/src/osdag_core/design_type/plate_girder/core/plate_girder.py
@@ -30,7 +30,7 @@ from .utils import ceil_to_nearest, get_K_from_warping_restraint, get_effective_
 # OPTIMIZATION & DEBUG CONFIGURATION
 # ==============================================================================
 USE_INTELLIGENT_PSO = True  # Set False to use legacy PSO
-DEBUG_MODE = True          # Set True to enable detail printing
+DEBUG_MODE = False          # Set True to enable detail printing
 # ==============================================================================
 from ..checks.shear import *
 from ..checks.web_buckling import *

--- a/src/osdag_core/design_type/plate_girder/core/plate_girder.py
+++ b/src/osdag_core/design_type/plate_girder/core/plate_girder.py
@@ -980,7 +980,7 @@ class PlateGirderWelded(Member):
         self.section_class = None
         if self.design_type == 'Optimized':
             self.total_depth = 1
-            if design_dictionary[KEY_WEB_THICKNESS_PG] == 'All':
+            if design_dictionary[KEY_WEB_THICKNESS_PG] in ('All', 'Customized'):
                 self.web_thickness_list = VALUES_PLATETHK_CUSTOMIZED
                 self.web_thickness = float(VALUES_PLATETHK_CUSTOMIZED[0])
             else:
@@ -988,7 +988,7 @@ class PlateGirderWelded(Member):
                 self.web_thickness = float(design_dictionary[KEY_WEB_THICKNESS_PG])
 
             self.top_flange_width = 1
-            if design_dictionary[KEY_TOP_FLANGE_THICKNESS_PG] == 'All':
+            if design_dictionary[KEY_TOP_FLANGE_THICKNESS_PG] in ('All', 'Customized'):
                 self.top_flange_thickness_list = VALUES_PLATETHK_CUSTOMIZED
                 self.top_flange_thickness = float(VALUES_PLATETHK_CUSTOMIZED[0])
             else:
@@ -996,7 +996,7 @@ class PlateGirderWelded(Member):
                 self.top_flange_thickness = float(design_dictionary[KEY_TOP_FLANGE_THICKNESS_PG])
 
             self.bottom_flange_width = 1
-            if design_dictionary[KEY_BOTTOM_FLANGE_THICKNESS_PG] == 'All':
+            if design_dictionary[KEY_BOTTOM_FLANGE_THICKNESS_PG] in ('All', 'Customized'):
                 self.bottom_flange_thickness_list = VALUES_PLATETHK_CUSTOMIZED
                 self.bottom_flange_thickness = float(VALUES_PLATETHK_CUSTOMIZED[0])
             else:
@@ -1005,7 +1005,7 @@ class PlateGirderWelded(Member):
 
         else:
             self.total_depth = float(design_dictionary[KEY_OVERALL_DEPTH_PG])
-            if design_dictionary[KEY_WEB_THICKNESS_PG] == 'All':
+            if design_dictionary[KEY_WEB_THICKNESS_PG] in ('All', 'Customized'):
                 self.web_thickness_list = VALUES_PLATETHK_CUSTOMIZED
                 self.web_thickness = float(VALUES_PLATETHK_CUSTOMIZED[0])
             else:
@@ -1013,7 +1013,7 @@ class PlateGirderWelded(Member):
                 self.web_thickness = float(design_dictionary[KEY_WEB_THICKNESS_PG])
 
             self.top_flange_width = float(design_dictionary[KEY_TOP_Bflange_PG])
-            if design_dictionary[KEY_TOP_FLANGE_THICKNESS_PG] == 'All':
+            if design_dictionary[KEY_TOP_FLANGE_THICKNESS_PG] in ('All', 'Customized'):
                 self.top_flange_thickness_list = VALUES_PLATETHK_CUSTOMIZED
                 self.top_flange_thickness = float(VALUES_PLATETHK_CUSTOMIZED[0])
             else:
@@ -1021,7 +1021,7 @@ class PlateGirderWelded(Member):
                 self.top_flange_thickness = float(design_dictionary[KEY_TOP_FLANGE_THICKNESS_PG])
 
             self.bottom_flange_width = float(design_dictionary[KEY_BOTTOM_Bflange_PG])
-            if design_dictionary[KEY_BOTTOM_FLANGE_THICKNESS_PG] == 'All':
+            if design_dictionary[KEY_BOTTOM_FLANGE_THICKNESS_PG] in ('All', 'Customized'):
                 self.bottom_flange_thickness_list = VALUES_PLATETHK_CUSTOMIZED
                 self.bottom_flange_thickness = float(VALUES_PLATETHK_CUSTOMIZED[0])
             else:

--- a/src/osdag_core/design_type/plate_girder/visualization/pso_visualizer.py
+++ b/src/osdag_core/design_type/plate_girder/visualization/pso_visualizer.py
@@ -525,9 +525,8 @@ class PSOVisualizerWidget(QDialog):
         
         # Window flags: Frameless to use CustomTitleBar
         self.setWindowFlags(
-            Qt.Dialog | 
-            Qt.FramelessWindowHint |
-            Qt.WindowStaysOnTopHint
+            Qt.Dialog |
+            Qt.FramelessWindowHint
         )
         self.setAttribute(Qt.WA_StyledBackground, True)
         


### PR DESCRIPTION
1. **PSO window no longer floats on top** (`pso_visualizer.py:527`): Removed `Qt.WindowStaysOnTopHint` from the PSO graph window flags, so it behaves like a normal window and doesn't stay on top of everything else you have open.

2. **Fixed crash on Customized thickness selection in Plate Girder** (`plate_girder.py:983-1029`): When the user picks "Customized" for web or flange thickness (in either Optimized or Standard mode), the code was trying to convert the string `'Customized'` to a float and crashing. Changed all 6 thickness checks from `== 'All'` to `in ('All', 'Customized')` so it now correctly falls back to the full `VALUES_PLATETHK_CUSTOMIZED` list in both cases.

3. **Debug mode turned off in PG module**: Set `debug` to `False` in the Plate Girder module so debug output doesn't leak into normal runs.