### PR TITLE
Refactor Weld Distribution Logic for Tension and Compression Members

### DIFF
--- a/src/osdag_core/cad/CompressionMembers/WeldedCAD.py
+++ b/src/osdag_core/cad/CompressionMembers/WeldedCAD.py
@@ -9,19 +9,13 @@ import copy
 from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Fuse
 
 class StrutAngleWeldCAD(object):
-    def __init__(self, Obj, member, plate, inline_weld, opline_weld, weld_plate_array):
-        """
-        :param member: Angle or Channel
-        :param plate: Plate
-        :param weld: weld
-        :param input: input parameters
-        :param memb_data: data of the members
-        """
+    def __init__(self, Obj, member, plate, inline_weld_toe, inline_weld_heel, opline_weld, weld_plate_array):
 
         self.Obj = Obj
         self.member = member
         self.plate = plate
-        self.inline_weld = inline_weld
+        self.inline_weld_toe = inline_weld_toe
+        self.inline_weld_heel = inline_weld_heel
         self.opline_weld = opline_weld
         self.intermittentConnection = weld_plate_array
 
@@ -32,29 +26,26 @@ class StrutAngleWeldCAD(object):
 
         self.member1 = copy.deepcopy(self.member)
         self.member2 = copy.deepcopy(self.member)
-        # self.member2 = copy.deepcopy(self.member)
 
-        # front side member
-        self.weldHL11 = copy.deepcopy(self.inline_weld)  # weld horizontal left side 1 (top side of member)
-        self.weldHL12 = copy.deepcopy(self.inline_weld)  # weld horzontal left side 2 (bottom side of member)
-        self.weldHR11 = copy.deepcopy(self.inline_weld)
-        self.weldHR12 = copy.deepcopy(self.inline_weld)
+        self.weldHL11 = copy.deepcopy(self.inline_weld_heel)
+        self.weldHL12 = copy.deepcopy(self.inline_weld_toe)
+        self.weldHR11 = copy.deepcopy(self.inline_weld_heel)
+        self.weldHR12 = copy.deepcopy(self.inline_weld_toe)
 
-        self.weldVL11 = copy.deepcopy(self.opline_weld)  # weld vertical left side
-        self.weldVR11 = copy.deepcopy(self.opline_weld)  # weld vertical right side
+        self.weldVL11 = copy.deepcopy(self.opline_weld)
+        self.weldVR11 = copy.deepcopy(self.opline_weld)
 
-        # for B2B members, back side member
-        self.weldHL21 = copy.deepcopy(self.inline_weld)  # weld horizontal left side 1 (top side of member)
-        self.weldHL22 = copy.deepcopy(self.inline_weld)  # weld horzontal left side 2 (bottom side of member)
-        self.weldHR21 = copy.deepcopy(self.inline_weld)
-        self.weldHR22 = copy.deepcopy(self.inline_weld)
+        self.weldHL21 = copy.deepcopy(self.inline_weld_heel)
+        self.weldHL22 = copy.deepcopy(self.inline_weld_toe)
+        self.weldHR21 = copy.deepcopy(self.inline_weld_heel)
+        self.weldHR22 = copy.deepcopy(self.inline_weld_toe)
 
-        self.weldVL21 = copy.deepcopy(self.opline_weld)  # weld vertical left side
-        self.weldVR21 = copy.deepcopy(self.opline_weld)  # weld vertical right side
+        self.weldVL21 = copy.deepcopy(self.opline_weld)
+        self.weldVR21 = copy.deepcopy(self.opline_weld)
 
-        self.s = max(15, self.inline_weld.h)
-        self.plate_intercept = self.plate.L - self.s - 50
-        self.inter_length = self.member.L - 2*(self.plate.L - 50)
+        self.s = max(15, self.inline_weld_toe.h)
+        self.plate_intercept = self.inline_weld_heel.L
+        self.inter_length = self.member.L - 2 * (self.plate.L - 50)
 
     def create_3DModel(self):
 
@@ -74,19 +65,19 @@ class StrutAngleWeldCAD(object):
                 self.member1_Model = self.member1.create_model()
 
             elif 'Back to Back Angles' in self.Obj.sec_profile:
+                # Member 1 — same as always
                 member1OriginL = numpy.array([-self.plate_intercept, 0.0, self.opline_weld.L / 2])
                 member1_uDir = numpy.array([0.0, -1.0, 0.0])
                 member1_wDir = numpy.array([1.0, 0.0, 0.0])
                 self.member1.place(member1OriginL, member1_uDir, member1_wDir)
-
                 self.member1_Model = self.member1.create_model()
 
+                # Member 2 — z is NEGATIVE (opposite side of gusset)
                 member2OriginL = numpy.array(
                     [self.member.L - self.plate_intercept, self.plate.T, self.opline_weld.L / 2])
                 member2_uDir = numpy.array([0.0, 1.0, 0.0])
                 member2_wDir = numpy.array([-1.0, 0.0, 0.0])
                 self.member2.place(member2OriginL, member2_uDir, member2_wDir)
-
                 self.member2_Model = self.member2.create_model()
 
             elif 'Star Angles' in self.Obj.sec_profile:
@@ -126,15 +117,16 @@ class StrutAngleWeldCAD(object):
                 member1_uDir = numpy.array([0.0, 0.0, -1.0])
                 member1_wDir = numpy.array([-1.0, 0.0, 0.0])
                 self.member1.place(member1OriginL, member1_uDir, member1_wDir)
-
                 self.member1_Model = self.member1.create_model()
 
-                member2OriginL = numpy.array([- self.plate_intercept, self.plate.T, self.opline_weld.L / 2])
+                # Member 2 — z is NEGATIVE (opposite side of gusset)
+                member2OriginL = numpy.array(
+                    [-self.plate_intercept, self.plate.T, -self.opline_weld.L / 2])
                 member2_uDir = numpy.array([0.0, 0.0, -1.0])
                 member2_wDir = numpy.array([1.0, 0.0, 0.0])
                 self.member2.place(member2OriginL, member2_uDir, member2_wDir)
-
                 self.member2_Model = self.member2.create_model()
+
 
             elif 'Star Angles' in self.Obj.sec_profile:
                 member1OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, 0.0])
@@ -164,202 +156,298 @@ class StrutAngleWeldCAD(object):
         plate1_uDir = numpy.array([1.0, 0.0, 0.0])
         plate1_wDir = numpy.array([0.0, 0.0, 1.0])
         self.plate1.place(plate1OriginL, plate1_uDir, plate1_wDir)
-
         self.plate1_Model = self.plate1.create_model()
 
         plate2OriginL = numpy.array([self.member.L - 2 * self.plate_intercept, self.plate.T, 0.0])
         plate2_uDir = numpy.array([-1.0, 0.0, 0.0])
         plate2_wDir = numpy.array([0.0, 0.0, 1.0])
         self.plate2.place(plate2OriginL, plate2_uDir, plate2_wDir)
-
         self.plate2_Model = self.plate2.create_model()
 
-        if ('Back to Back Angles' in self.Obj.sec_profile or 'Back to Back Channels' in self.Obj.sec_profile or 'Star Angles' in self.Obj.sec_profile) and self.inter_length > 1000:
-            intermittentConnectionOriginL = numpy.array([0, 0.0, 0.0])
-            intermittentConnection_uDir = numpy.array([1.0, 0.0, 0.0])
-            intermittentConnection_vDir = numpy.array([0.0, 1.0, 0.0])
-            intermittentConnection_wDir = numpy.array([0.0, 0.0, 1.0])
-            self.intermittentConnection.place(intermittentConnectionOriginL, intermittentConnection_uDir,
-                                              intermittentConnection_vDir, intermittentConnection_wDir)
+        if (('Back to Back Angles' in self.Obj.sec_profile
+             or 'Back to Back Channels' in self.Obj.sec_profile
+             or 'Star Angles' in self.Obj.sec_profile)
+                and self.inter_length > 1000):
 
-            self.intermittentConnection_Model = self.intermittentConnection.create_model()
-            self.inter_conc_welds = self.intermittentConnection.get_welded_models()
-            self.inter_conc_plates = self.intermittentConnection.get_plate_models()
+            ic_weld_size = self.intermittentConnection.weld.h \
+                if hasattr(self.intermittentConnection, 'weld') \
+                else 0.0
+            ic_plate_width = self.intermittentConnection.plate.W \
+                if hasattr(self.intermittentConnection, 'plate') \
+                else 0.0
+
+            if ic_weld_size > 0 and ic_plate_width > 0:
+                ic_origin = numpy.array([0.0, 0.0, 0.0])
+                ic_uDir = numpy.array([1.0, 0.0, 0.0])
+                ic_vDir = numpy.array([0.0, 1.0, 0.0])
+                ic_wDir = numpy.array([0.0, 0.0, 1.0])
+                self.intermittentConnection.place(ic_origin, ic_uDir, ic_vDir, ic_wDir)
+                self.intermittentConnection_Model = self.intermittentConnection.create_model()
+                self.inter_conc_welds = self.intermittentConnection.get_welded_models()
+                self.inter_conc_plates = self.intermittentConnection.get_plate_models()
+            else:
+                # Intermittent data not available — treat as if inter_length <= 1000
+                self.inter_length = 0
 
     def createWeldGeometry(self):
-        if 'Back to Back Angles' in self.Obj.sec_profile or ('Angles' in self.Obj.sec_profile and 'Back to Back' not in self.Obj.sec_profile) or 'Channels' in self.Obj.sec_profile:
-            weldHL11OriginL = numpy.array([-self.plate_intercept, 0.0, self.opline_weld.L / 2])
+        if ('Angles' in self.Obj.sec_profile
+                or 'Channels' in self.Obj.sec_profile):
+
+            # Left end — TOP flange (HEEL, longer)
+            weldHL11OriginL = numpy.array([
+                -self.plate_intercept, 0.0, self.opline_weld.L / 2
+            ])
             weldHL11_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHL11_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHL11.place(weldHL11OriginL, weldHL11_uDir, weldHL11_wDir)
-
             self.weldHL11_Model = self.weldHL11.create_model()
 
-            weldHL12OriginL = numpy.array([0.0, 0.0, -self.opline_weld.L / 2])
+            # Left end — BOTTOM flange (TOE, shorter)
+            weldHL12OriginL = numpy.array([
+                -self.plate_intercept + self.inline_weld_toe.L,
+                0.0,
+                -self.opline_weld.L / 2
+            ])
             weldHL12_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
-
             self.weldHL12_Model = self.weldHL12.create_model()
 
-            weldHR11OriginL = numpy.array([-2 * self.plate_intercept + self.member.L, 0.0, self.opline_weld.L / 2])
+            # Right end — TOP flange (HEEL, longer)
+            weldHR11OriginL = numpy.array([
+                -self.plate_intercept + self.member.L - self.inline_weld_heel.L,
+                0.0,
+                self.opline_weld.L / 2
+            ])
             weldHR11_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHR11_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
-
             self.weldHR11_Model = self.weldHR11.create_model()
 
-            weldHR12OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, -self.opline_weld.L / 2])
+            # Right end — BOTTOM flange (TOE, shorter)
+            weldHR12OriginL = numpy.array([
+                -self.plate_intercept + self.member.L,
+                0.0,
+                -self.opline_weld.L / 2
+            ])
             weldHR12_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHR12_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHR12.place(weldHR12OriginL, weldHR12_uDir, weldHR12_wDir)
-
             self.weldHR12_Model = self.weldHR12.create_model()
 
-            weldVL11OriginL = numpy.array([-self.plate_intercept, 0.0, -self.opline_weld.L / 2])
+            # Left transverse (opline) weld
+            weldVL11OriginL = numpy.array([
+                -self.plate_intercept, 0.0, -self.opline_weld.L / 2
+            ])
             weldVL11_uDir = numpy.array([-1.0, 0.0, 0.0])
             weldVL11_wDir = numpy.array([0.0, 0.0, 1.0])
             self.weldVL11.place(weldVL11OriginL, weldVL11_uDir, weldVL11_wDir)
-
             self.weldVL11_Model = self.weldVL11.create_model()
 
-            weldVR11OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, self.opline_weld.L / 2])
+            # Right transverse (opline) weld
+            weldVR11OriginL = numpy.array([
+                -self.plate_intercept + self.member.L,
+                0.0,
+                self.opline_weld.L / 2
+            ])
             weldVR11_uDir = numpy.array([1.0, 0.0, 0.0])
             weldVR11_wDir = numpy.array([0.0, 0.0, -1.0])
             self.weldVR11.place(weldVR11OriginL, weldVR11_uDir, weldVR11_wDir)
-
             self.weldVR11_Model = self.weldVR11.create_model()
-
-        if 'Back to Back Angles' in self.Obj.sec_profile or 'Back to Back Channels' in self.Obj.sec_profile:
-            weldHL21OriginL = numpy.array([0.0, self.plate.T, self.opline_weld.L / 2])
-            weldHL21_uDir = numpy.array([0.0, 0.0, 1.0])
-            weldHL21_wDir = numpy.array([-1.0, 0.0, 0.0])
-            self.weldHL21.place(weldHL21OriginL, weldHL21_uDir, weldHL21_wDir)
-
-            self.weldHL21_Model = self.weldHL21.create_model()
-
-            weldHL22OriginL = numpy.array([- self.plate_intercept, self.plate.T, -self.opline_weld.L / 2])
-            weldHL22_uDir = numpy.array([0.0, 0.0, -1.0])
-            weldHL22_wDir = numpy.array([1.0, 0.0, 0.0])
-            self.weldHL22.place(weldHL22OriginL, weldHL22_uDir, weldHL22_wDir)
-
-            self.weldHL22_Model = self.weldHL22.create_model()
-
-            weldHR21OriginL = numpy.array(
-                [- self.plate_intercept + self.member.L, self.plate.T, self.opline_weld.L / 2])
-            weldHR21_uDir = numpy.array([0.0, 0.0, 1.0])
-            weldHR21_wDir = numpy.array([-1.0, 0.0, 0.0])
-            self.weldHR21.place(weldHR21OriginL, weldHR21_uDir, weldHR21_wDir)
-
-            self.weldHR21_Model = self.weldHR21.create_model()
-
-            weldHR22OriginL = numpy.array(
-                [-2 * self.plate_intercept + self.member.L, self.plate.T, -self.opline_weld.L / 2])
-            weldHR22_uDir = numpy.array([0.0, 0.0, -1.0])
-            weldHR22_wDir = numpy.array([1.0, 0.0, 0.0])
-            self.weldHR22.place(weldHR22OriginL, weldHR22_uDir, weldHR22_wDir)
-
-            self.weldHR22_Model = self.weldHR22.create_model()
-
-            weldVL21OriginL = numpy.array([-self.plate_intercept, self.plate.T, self.opline_weld.L / 2])
-            weldVL21_uDir = numpy.array([-1.0, 0.0, 0.0])
-            weldVL21_wDir = numpy.array([0.0, 0.0, -1.0])
-            self.weldVL21.place(weldVL21OriginL, weldVL21_uDir, weldVL21_wDir)
-
-            self.weldVL21_Model = self.weldVL21.create_model()
-
-            weldVR21OriginL = numpy.array(
-                [-self.plate_intercept + self.member.L, self.plate.T, -self.opline_weld.L / 2])
-            weldVR21_uDir = numpy.array([1.0, 0.0, 0.0])
-            weldVR21_wDir = numpy.array([0.0, 0.0, 1.0])
-            self.weldVR21.place(weldVR21OriginL, weldVR21_uDir, weldVR21_wDir)
-
-            self.weldVR21_Model = self.weldVR21.create_model()
 
         elif 'Star Angles' in self.Obj.sec_profile:
 
-            weldHL11OriginL = numpy.array([-self.plate_intercept, 0.0, 0.0])
+            # ---- Member 1, near face (y = 0) ----
+
+            # Left end — TOP (HEEL)
+            weldHL11OriginL = numpy.array([
+                -self.plate_intercept, 0.0, 0.0
+            ])
             weldHL11_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHL11_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHL11.place(weldHL11OriginL, weldHL11_uDir, weldHL11_wDir)
-
             self.weldHL11_Model = self.weldHL11.create_model()
 
-            weldHL12OriginL = numpy.array([0.0, 0.0, -self.opline_weld.L])
+            # Left end — BOTTOM (TOE)
+            weldHL12OriginL = numpy.array([
+                -self.plate_intercept + self.inline_weld_toe.L,
+                0.0,
+                -self.opline_weld.L
+            ])
             weldHL12_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
-
             self.weldHL12_Model = self.weldHL12.create_model()
 
-            weldHR11OriginL = numpy.array([-2 * self.plate_intercept + self.member.L, 0.0, 0.0])
+            # Right end — TOP (HEEL)
+            weldHR11OriginL = numpy.array([
+                -self.plate_intercept + self.member.L - self.inline_weld_heel.L,
+                0.0,
+                0.0
+            ])
             weldHR11_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHR11_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
-
             self.weldHR11_Model = self.weldHR11.create_model()
 
-            weldHR12OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, -self.opline_weld.L])
+            # Right end — BOTTOM (TOE)
+            weldHR12OriginL = numpy.array([
+                -self.plate_intercept + self.member.L,
+                0.0,
+                -self.opline_weld.L
+            ])
             weldHR12_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHR12_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHR12.place(weldHR12OriginL, weldHR12_uDir, weldHR12_wDir)
-
             self.weldHR12_Model = self.weldHR12.create_model()
 
-            weldVL11OriginL = numpy.array([-self.plate_intercept, 0.0, -self.opline_weld.L])
+            # Left opline (member 1)
+            weldVL11OriginL = numpy.array([
+                -self.plate_intercept, 0.0, -self.opline_weld.L
+            ])
             weldVL11_uDir = numpy.array([-1.0, 0.0, 0.0])
             weldVL11_wDir = numpy.array([0.0, 0.0, 1.0])
             self.weldVL11.place(weldVL11OriginL, weldVL11_uDir, weldVL11_wDir)
-
             self.weldVL11_Model = self.weldVL11.create_model()
 
-            weldVR11OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, 0.0])
+            # Right opline (member 1)
+            weldVR11OriginL = numpy.array([
+                -self.plate_intercept + self.member.L, 0.0, 0.0
+            ])
             weldVR11_uDir = numpy.array([1.0, 0.0, 0.0])
             weldVR11_wDir = numpy.array([0.0, 0.0, -1.0])
             self.weldVR11.place(weldVR11OriginL, weldVR11_uDir, weldVR11_wDir)
-
             self.weldVR11_Model = self.weldVR11.create_model()
 
-            weldHL21OriginL = numpy.array([0.0, self.plate.T, self.opline_weld.L])
+            # ---- Member 2, far face (y = plate.T), reversed in x ----
+            # Heel end of member 2 is at the LEFT side of the gusset.
+
+            # Left end — TOP (HEEL, mirrored)
+            weldHL21OriginL = numpy.array([
+                -self.plate_intercept + self.inline_weld_heel.L,
+                self.plate.T + self.inline_weld_toe.h,
+                self.opline_weld.L
+            ])
             weldHL21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHL21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL21.place(weldHL21OriginL, weldHL21_uDir, weldHL21_wDir)
-
             self.weldHL21_Model = self.weldHL21.create_model()
 
-            weldHL22OriginL = numpy.array([- self.plate_intercept, self.plate.T, 0.0])
+            # Left end — BOTTOM (TOE, mirrored)
+            weldHL22OriginL = numpy.array([
+                -self.plate_intercept, self.plate.T, 0.0
+            ])
             weldHL22_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHL22_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHL22.place(weldHL22OriginL, weldHL22_uDir, weldHL22_wDir)
-
             self.weldHL22_Model = self.weldHL22.create_model()
 
-            weldHR21OriginL = numpy.array([-self.plate_intercept + self.member.L, self.plate.T, self.opline_weld.L])
+            # Right end — TOP (HEEL, mirrored)
+            weldHR21OriginL = numpy.array([
+                -self.plate_intercept + self.member.L,
+                self.plate.T + self.inline_weld_toe.h,
+                self.opline_weld.L
+            ])
             weldHR21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHR21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHR21.place(weldHR21OriginL, weldHR21_uDir, weldHR21_wDir)
-
             self.weldHR21_Model = self.weldHR21.create_model()
 
-            weldHR22OriginL = numpy.array([-2 * self.plate_intercept + self.member.L, self.plate.T, 0.0])
+            # Right end — BOTTOM (TOE, mirrored)
+            weldHR22OriginL = numpy.array([
+                -self.plate_intercept + self.member.L - self.inline_weld_heel.L,
+                self.plate.T,
+                0.0
+            ])
             weldHR22_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHR22_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR22.place(weldHR22OriginL, weldHR22_uDir, weldHR22_wDir)
-
             self.weldHR22_Model = self.weldHR22.create_model()
 
-            weldVL21OriginL = numpy.array([-self.plate_intercept, self.plate.T, self.opline_weld.L])
+            # Left opline (member 2)
+            weldVL21OriginL = numpy.array([
+                -self.plate_intercept, self.plate.T, self.opline_weld.L
+            ])
             weldVL21_uDir = numpy.array([-1.0, 0.0, 0.0])
             weldVL21_wDir = numpy.array([0.0, 0.0, -1.0])
             self.weldVL21.place(weldVL21OriginL, weldVL21_uDir, weldVL21_wDir)
-
             self.weldVL21_Model = self.weldVL21.create_model()
 
-            weldVR21OriginL = numpy.array([-self.plate_intercept + self.member.L, self.plate.T, 0.0])
+            # Right opline (member 2)
+            weldVR21OriginL = numpy.array([
+                -self.plate_intercept + self.member.L, self.plate.T, 0.0
+            ])
             weldVR21_uDir = numpy.array([1.0, 0.0, 0.0])
             weldVR21_wDir = numpy.array([0.0, 0.0, 1.0])
             self.weldVR21.place(weldVR21OriginL, weldVR21_uDir, weldVR21_wDir)
+            self.weldVR21_Model = self.weldVR21.create_model()
 
+        if ('Back to Back Angles' in self.Obj.sec_profile
+                or 'Back to Back Channels' in self.Obj.sec_profile):
+            # Left end — TOP (HEEL, reversed member 2)
+            weldHL21OriginL = numpy.array([
+                -self.plate_intercept + self.inline_weld_heel.L,
+                self.plate.T,
+                self.opline_weld.L / 2
+            ])
+            weldHL21_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHL21_wDir = numpy.array([-1.0, 0.0, 0.0])
+            self.weldHL21.place(weldHL21OriginL, weldHL21_uDir, weldHL21_wDir)
+            self.weldHL21_Model = self.weldHL21.create_model()
+
+            # Left end — BOTTOM (TOE, reversed member 2)
+            weldHL22OriginL = numpy.array([
+                -self.plate_intercept,
+                self.plate.T,
+                -self.opline_weld.L / 2
+            ])
+            weldHL22_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHL22_wDir = numpy.array([1.0, 0.0, 0.0])
+            self.weldHL22.place(weldHL22OriginL, weldHL22_uDir, weldHL22_wDir)
+            self.weldHL22_Model = self.weldHL22.create_model()
+
+            # Right end — TOP (HEEL, reversed member 2 toe side)
+            weldHR21OriginL = numpy.array([
+                -self.plate_intercept + self.member.L,
+                self.plate.T,
+                self.opline_weld.L / 2
+            ])
+            weldHR21_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHR21_wDir = numpy.array([-1.0, 0.0, 0.0])
+            self.weldHR21.place(weldHR21OriginL, weldHR21_uDir, weldHR21_wDir)
+            self.weldHR21_Model = self.weldHR21.create_model()
+
+            # Right end — BOTTOM (TOE, reversed member 2 toe side)
+            weldHR22OriginL = numpy.array([
+                -self.plate_intercept + self.member.L - self.inline_weld_toe.L,
+                self.plate.T,
+                -self.opline_weld.L / 2
+            ])
+            weldHR22_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHR22_wDir = numpy.array([1.0, 0.0, 0.0])
+            self.weldHR22.place(weldHR22OriginL, weldHR22_uDir, weldHR22_wDir)
+            self.weldHR22_Model = self.weldHR22.create_model()
+
+            # Left opline (member 2)
+            weldVL21OriginL = numpy.array([
+                -self.plate_intercept,
+                self.plate.T,
+                self.opline_weld.L / 2
+            ])
+            weldVL21_uDir = numpy.array([-1.0, 0.0, 0.0])
+            weldVL21_wDir = numpy.array([0.0, 0.0, -1.0])
+            self.weldVL21.place(weldVL21OriginL, weldVL21_uDir, weldVL21_wDir)
+            self.weldVL21_Model = self.weldVL21.create_model()
+
+            # Right opline (member 2)
+            weldVR21OriginL = numpy.array([
+                -self.plate_intercept + self.member.L,
+                self.plate.T,
+                -self.opline_weld.L / 2
+            ])
+            weldVR21_uDir = numpy.array([1.0, 0.0, 0.0])
+            weldVR21_wDir = numpy.array([0.0, 0.0, 1.0])
+            self.weldVR21.place(weldVR21OriginL, weldVR21_uDir, weldVR21_wDir)
             self.weldVR21_Model = self.weldVR21.create_model()
 
 
@@ -404,7 +492,7 @@ class StrutAngleWeldCAD(object):
         if ('Angles' in self.Obj.sec_profile and 'Back to Back' not in self.Obj.sec_profile) or 'Channels' in self.Obj.sec_profile:
             welded_sec = [self.weldHL11_Model, self.weldHL12_Model, self.weldHR11_Model, self.weldHR12_Model,
                           self.weldVL11_Model, self.weldVR11_Model]
-        elif ('Back to Back Angles' in self.Obj.sec_profile or 'Back to Back Channels' in self.Obj.sec_profile or 'Star Angles' in self.Obj.sec_profile) and self.inter_length > 1000:
+        elif ('Back to Back Angles' in self.Obj.sec_profile or 'Back to Back Channels' in self.Obj.sec_profile or 'Star Angles' in self.Obj.sec_profile) and self.inter_length > 1000 and hasattr(self, 'inter_conc_welds'):
             welded_sec = [self.weldHL11_Model, self.weldHL12_Model, self.weldHR11_Model, self.weldHR12_Model,
                           self.weldVL11_Model, self.weldVR11_Model, self.weldHL21_Model, self.weldHL22_Model,
                           self.weldHR21_Model, self.weldHR22_Model, self.weldVL21_Model, self.weldVR21_Model,

--- a/src/osdag_core/cad/Tension/WeldedCAD.py
+++ b/src/osdag_core/cad/Tension/WeldedCAD.py
@@ -2,6 +2,9 @@
 Initialized on 23-04-2020
 Comenced on
 @author: Anand Swaroop
+
+Edited on 24-03-2026
+@author: Omkar Kottawar
 """
 
 import numpy
@@ -9,52 +12,41 @@ import copy
 from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Fuse
 
 class TensionAngleWeldCAD(object):
-    def __init__(self, Obj, member, plate, inline_weld, opline_weld, weld_plate_array):
-        """
-        :param member: Angle or Channel
-        :param plate: Plate
-        :param weld: weld
-        :param input: input parameters
-        :param memb_data: data of the members
-        """
+    def __init__(self, Obj, member, plate, inline_weld_toe, inline_weld_heel, opline_weld, weld_plate_array):
 
         self.Obj = Obj
         self.member = member
         self.plate = plate
-        self.inline_weld = inline_weld
+        self.inline_weld_toe = inline_weld_toe
+        self.inline_weld_heel = inline_weld_heel
         self.opline_weld = opline_weld
         self.intermittentConnection = weld_plate_array
 
-        # self.Obj.loc = 'Long Leg'#'Short Leg'
-
         self.plate1 = copy.deepcopy(self.plate)
         self.plate2 = copy.deepcopy(self.plate)
-
         self.member1 = copy.deepcopy(self.member)
         self.member2 = copy.deepcopy(self.member)
-        # self.member2 = copy.deepcopy(self.member)
 
-        # front side member
-        self.weldHL11 = copy.deepcopy(self.inline_weld)  # weld horizontal left side 1 (top side of member)
-        self.weldHL12 = copy.deepcopy(self.inline_weld)  # weld horzontal left side 2 (bottom side of member)
-        self.weldHR11 = copy.deepcopy(self.inline_weld)
-        self.weldHR12 = copy.deepcopy(self.inline_weld)
+        self.weldHL11 = copy.deepcopy(self.inline_weld_toe)
+        self.weldHL12 = copy.deepcopy(self.inline_weld_toe)
+        self.weldHR11 = copy.deepcopy(self.inline_weld_heel)
+        self.weldHR12 = copy.deepcopy(self.inline_weld_heel)
 
-        self.weldVL11 = copy.deepcopy(self.opline_weld)  # weld vertical left side
-        self.weldVR11 = copy.deepcopy(self.opline_weld)  # weld vertical right side
+        self.weldVL11 = copy.deepcopy(self.opline_weld)
+        self.weldVR11 = copy.deepcopy(self.opline_weld)
 
-        # for B2B members, back side member
-        self.weldHL21 = copy.deepcopy(self.inline_weld)  # weld horizontal left side 1 (top side of member)
-        self.weldHL22 = copy.deepcopy(self.inline_weld)  # weld horzontal left side 2 (bottom side of member)
-        self.weldHR21 = copy.deepcopy(self.inline_weld)
-        self.weldHR22 = copy.deepcopy(self.inline_weld)
+        # back side member (B2B / Star)
+        self.weldHL21 = copy.deepcopy(self.inline_weld_toe)
+        self.weldHL22 = copy.deepcopy(self.inline_weld_toe)
+        self.weldHR21 = copy.deepcopy(self.inline_weld_heel)
+        self.weldHR22 = copy.deepcopy(self.inline_weld_heel)
 
-        self.weldVL21 = copy.deepcopy(self.opline_weld)  # weld vertical left side
-        self.weldVR21 = copy.deepcopy(self.opline_weld)  # weld vertical right side
+        self.weldVL21 = copy.deepcopy(self.opline_weld)
+        self.weldVR21 = copy.deepcopy(self.opline_weld)
 
-        self.s = max(15, self.inline_weld.h)
+        self.s = max(15, self.inline_weld_toe.h)  # size unchanged, use either — both share weld.size
         self.plate_intercept = self.plate.L - self.s - 50
-        self.inter_length = self.member.L - 2*(self.plate.L - 50)
+        self.inter_length = self.member.L - 2 * (self.plate.L - 50)
 
     def create_3DModel(self):
 
@@ -171,85 +163,155 @@ class TensionAngleWeldCAD(object):
             self.inter_conc_plates = self.intermittentConnection.get_plate_models()
 
     def createWeldGeometry(self):
-        if self.Obj.sec_profile == 'Back to Back Angles' or self.Obj.sec_profile == 'Angles' or self.Obj.sec_profile == 'Channels' or self.Obj.sec_profile == 'Back to Back Channels':
+
+        if self.Obj.sec_profile == 'Angles':
+
             weldHL11OriginL = numpy.array([-self.plate_intercept, 0.0, self.opline_weld.L / 2])
             weldHL11_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHL11_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHL11.place(weldHL11OriginL, weldHL11_uDir, weldHL11_wDir)
-
             self.weldHL11_Model = self.weldHL11.create_model()
 
-            weldHL12OriginL = numpy.array([0.0, 0.0, -self.opline_weld.L / 2])
-            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0])
-            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0])
+            weldHL12OriginL = numpy.array([-self.plate_intercept + self.inline_weld_toe.L, 0.0, -self.opline_weld.L / 2])
+            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0]) # was [0.0, 0.0, -1.0]
+            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0]) # was [-1.0, 0.0, 0.0]
             self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
-
             self.weldHL12_Model = self.weldHL12.create_model()
 
-            weldHR11OriginL = numpy.array([-2 * self.plate_intercept + self.member.L, 0.0, self.opline_weld.L / 2])
-            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0])
-            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0])
+            weldHR11OriginL = numpy.array(
+                [-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
+            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0]) # was [0.0, 0.0, 1.0]
+            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0]) # was [1.0, 0.0, 0.0]
             self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
-
             self.weldHR11_Model = self.weldHR11.create_model()
 
             weldHR12OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, -self.opline_weld.L / 2])
             weldHR12_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHR12_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHR12.place(weldHR12OriginL, weldHR12_uDir, weldHR12_wDir)
-
             self.weldHR12_Model = self.weldHR12.create_model()
 
             weldVL11OriginL = numpy.array([-self.plate_intercept, 0.0, -self.opline_weld.L / 2])
             weldVL11_uDir = numpy.array([-1.0, 0.0, 0.0])
             weldVL11_wDir = numpy.array([0.0, 0.0, 1.0])
             self.weldVL11.place(weldVL11OriginL, weldVL11_uDir, weldVL11_wDir)
-
             self.weldVL11_Model = self.weldVL11.create_model()
 
             weldVR11OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, self.opline_weld.L / 2])
             weldVR11_uDir = numpy.array([1.0, 0.0, 0.0])
             weldVR11_wDir = numpy.array([0.0, 0.0, -1.0])
             self.weldVR11.place(weldVR11OriginL, weldVR11_uDir, weldVR11_wDir)
-
             self.weldVR11_Model = self.weldVR11.create_model()
 
-        if self.Obj.sec_profile == 'Back to Back Angles' or self.Obj.sec_profile == 'Back to Back Channels':
-            weldHL21OriginL = numpy.array([0.0, self.plate.T, self.opline_weld.L / 2])
+        elif self.Obj.sec_profile == 'Channels':
+
+            weldHL11OriginL = numpy.array([-self.plate_intercept, 0.0, self.opline_weld.L / 2])
+            weldHL11_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHL11_wDir = numpy.array([1.0, 0.0, 0.0])
+            self.weldHL11.place(weldHL11OriginL, weldHL11_uDir, weldHL11_wDir)
+            self.weldHL11_Model = self.weldHL11.create_model()
+
+            weldHL12OriginL = numpy.array([-self.plate_intercept + self.inline_weld_toe.L, 0.0, -self.opline_weld.L / 2])
+            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0]) # was [0.0, 0.0, -1.0]
+            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0]) # was [-1.0, 0.0, 0.0]
+            self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
+            self.weldHL12_Model = self.weldHL12.create_model()
+
+            weldHR11OriginL = numpy.array(
+                [-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
+            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0]) # was [0.0, 0.0, 1.0]
+            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0]) # was [1.0, 0.0, 0.0]
+            self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
+            self.weldHR11_Model = self.weldHR11.create_model()
+
+            weldHR12OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, -self.opline_weld.L / 2])
+            weldHR12_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHR12_wDir = numpy.array([-1.0, 0.0, 0.0])
+            self.weldHR12.place(weldHR12OriginL, weldHR12_uDir, weldHR12_wDir)
+            self.weldHR12_Model = self.weldHR12.create_model()
+
+            weldVL11OriginL = numpy.array([-self.plate_intercept, 0.0, -self.opline_weld.L / 2])
+            weldVL11_uDir = numpy.array([-1.0, 0.0, 0.0])
+            weldVL11_wDir = numpy.array([0.0, 0.0, 1.0])
+            self.weldVL11.place(weldVL11OriginL, weldVL11_uDir, weldVL11_wDir)
+            self.weldVL11_Model = self.weldVL11.create_model()
+
+            weldVR11OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, self.opline_weld.L / 2])
+            weldVR11_uDir = numpy.array([1.0, 0.0, 0.0])
+            weldVR11_wDir = numpy.array([0.0, 0.0, -1.0])
+            self.weldVR11.place(weldVR11OriginL, weldVR11_uDir, weldVR11_wDir)
+            self.weldVR11_Model = self.weldVR11.create_model()
+
+        elif self.Obj.sec_profile == 'Back to Back Angles':
+
+            weldHL11OriginL = numpy.array([-self.plate_intercept, 0.0, self.opline_weld.L / 2])
+            weldHL11_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHL11_wDir = numpy.array([1.0, 0.0, 0.0])
+            self.weldHL11.place(weldHL11OriginL, weldHL11_uDir, weldHL11_wDir)
+            self.weldHL11_Model = self.weldHL11.create_model()
+
+            weldHL12OriginL = numpy.array([-self.plate_intercept + self.inline_weld_toe.L, 0.0, -self.opline_weld.L / 2])
+            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0]) # was [0.0, 0.0, -1.0]
+            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0]) # was [-1.0, 0.0, 0.0]
+            self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
+            self.weldHL12_Model = self.weldHL12.create_model()
+
+            weldHR11OriginL = numpy.array(
+                [-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
+            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0]) # was [0.0, 0.0, 1.0]
+            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0]) # was [1.0, 0.0, 0.0]
+            self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
+            self.weldHR11_Model = self.weldHR11.create_model()
+
+            weldHR12OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, -self.opline_weld.L / 2])
+            weldHR12_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHR12_wDir = numpy.array([-1.0, 0.0, 0.0])
+            self.weldHR12.place(weldHR12OriginL, weldHR12_uDir, weldHR12_wDir)
+            self.weldHR12_Model = self.weldHR12.create_model()
+
+            weldVL11OriginL = numpy.array([-self.plate_intercept, 0.0, -self.opline_weld.L / 2])
+            weldVL11_uDir = numpy.array([-1.0, 0.0, 0.0])
+            weldVL11_wDir = numpy.array([0.0, 0.0, 1.0])
+            self.weldVL11.place(weldVL11OriginL, weldVL11_uDir, weldVL11_wDir)
+            self.weldVL11_Model = self.weldVL11.create_model()
+
+            weldVR11OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, self.opline_weld.L / 2])
+            weldVR11_uDir = numpy.array([1.0, 0.0, 0.0])
+            weldVR11_wDir = numpy.array([0.0, 0.0, -1.0])
+            self.weldVR11.place(weldVR11OriginL, weldVR11_uDir, weldVR11_wDir)
+            self.weldVR11_Model = self.weldVR11.create_model()
+
+            weldHL21OriginL = numpy.array(
+                [-self.plate_intercept + self.inline_weld_toe.L, self.plate.T, self.opline_weld.L / 2])
             weldHL21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHL21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL21.place(weldHL21OriginL, weldHL21_uDir, weldHL21_wDir)
-
             self.weldHL21_Model = self.weldHL21.create_model()
 
-            weldHL22OriginL = numpy.array([- self.plate_intercept, self.plate.T, -self.opline_weld.L / 2])
+            weldHL22OriginL = numpy.array([-self.plate_intercept, self.plate.T, -self.opline_weld.L / 2])
             weldHL22_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHL22_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHL22.place(weldHL22OriginL, weldHL22_uDir, weldHL22_wDir)
-
             self.weldHL22_Model = self.weldHL22.create_model()
 
             weldHR21OriginL = numpy.array(
-                [- self.plate_intercept + self.member.L, self.plate.T, self.opline_weld.L / 2])
+                [-self.plate_intercept + self.member.L, self.plate.T, self.opline_weld.L / 2])
             weldHR21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHR21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHR21.place(weldHR21OriginL, weldHR21_uDir, weldHR21_wDir)
-
             self.weldHR21_Model = self.weldHR21.create_model()
 
             weldHR22OriginL = numpy.array(
-                [-2 * self.plate_intercept + self.member.L, self.plate.T, -self.opline_weld.L / 2])
+                [-self.plate_intercept + self.member.L - self.inline_weld_heel.L, self.plate.T, -self.opline_weld.L / 2])
             weldHR22_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHR22_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR22.place(weldHR22OriginL, weldHR22_uDir, weldHR22_wDir)
-
             self.weldHR22_Model = self.weldHR22.create_model()
 
             weldVL21OriginL = numpy.array([-self.plate_intercept, self.plate.T, self.opline_weld.L / 2])
             weldVL21_uDir = numpy.array([-1.0, 0.0, 0.0])
             weldVL21_wDir = numpy.array([0.0, 0.0, -1.0])
             self.weldVL21.place(weldVL21OriginL, weldVL21_uDir, weldVL21_wDir)
-
             self.weldVL21_Model = self.weldVL21.create_model()
 
             weldVR21OriginL = numpy.array(
@@ -257,7 +319,85 @@ class TensionAngleWeldCAD(object):
             weldVR21_uDir = numpy.array([1.0, 0.0, 0.0])
             weldVR21_wDir = numpy.array([0.0, 0.0, 1.0])
             self.weldVR21.place(weldVR21OriginL, weldVR21_uDir, weldVR21_wDir)
+            self.weldVR21_Model = self.weldVR21.create_model()
 
+        elif self.Obj.sec_profile == 'Back to Back Channels':
+
+            weldHL11OriginL = numpy.array([-self.plate_intercept, 0.0, self.opline_weld.L / 2])
+            weldHL11_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHL11_wDir = numpy.array([1.0, 0.0, 0.0])
+            self.weldHL11.place(weldHL11OriginL, weldHL11_uDir, weldHL11_wDir)
+            self.weldHL11_Model = self.weldHL11.create_model()
+
+            weldHL12OriginL = numpy.array([-self.plate_intercept + self.inline_weld_toe.L, 0.0, -self.opline_weld.L / 2])
+            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0]) # was [0.0, 0.0, -1.0]
+            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0]) # was [-1.0, 0.0, 0.0]
+            self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
+            self.weldHL12_Model = self.weldHL12.create_model()
+
+            weldHR11OriginL = numpy.array(
+                [-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
+            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0]) # was [0.0, 0.0, 1.0]
+            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0]) # was [1.0, 0.0, 0.0]
+            self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
+            self.weldHR11_Model = self.weldHR11.create_model()
+
+            weldHR12OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, -self.opline_weld.L / 2])
+            weldHR12_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHR12_wDir = numpy.array([-1.0, 0.0, 0.0])
+            self.weldHR12.place(weldHR12OriginL, weldHR12_uDir, weldHR12_wDir)
+            self.weldHR12_Model = self.weldHR12.create_model()
+
+            weldVL11OriginL = numpy.array([-self.plate_intercept, 0.0, -self.opline_weld.L / 2])
+            weldVL11_uDir = numpy.array([-1.0, 0.0, 0.0])
+            weldVL11_wDir = numpy.array([0.0, 0.0, 1.0])
+            self.weldVL11.place(weldVL11OriginL, weldVL11_uDir, weldVL11_wDir)
+            self.weldVL11_Model = self.weldVL11.create_model()
+
+            weldVR11OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, self.opline_weld.L / 2])
+            weldVR11_uDir = numpy.array([1.0, 0.0, 0.0])
+            weldVR11_wDir = numpy.array([0.0, 0.0, -1.0])
+            self.weldVR11.place(weldVR11OriginL, weldVR11_uDir, weldVR11_wDir)
+            self.weldVR11_Model = self.weldVR11.create_model()
+
+            weldHL21OriginL = numpy.array(
+                [-self.plate_intercept + self.inline_weld_heel.L, self.plate.T, self.opline_weld.L / 2])
+            weldHL21_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHL21_wDir = numpy.array([-1.0, 0.0, 0.0])
+            self.weldHL21.place(weldHL21OriginL, weldHL21_uDir, weldHL21_wDir)
+            self.weldHL21_Model = self.weldHL21.create_model()
+
+            weldHL22OriginL = numpy.array([-self.plate_intercept, self.plate.T, -self.opline_weld.L / 2])
+            weldHL22_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHL22_wDir = numpy.array([1.0, 0.0, 0.0])
+            self.weldHL22.place(weldHL22OriginL, weldHL22_uDir, weldHL22_wDir)
+            self.weldHL22_Model = self.weldHL22.create_model()
+
+            weldHR21OriginL = numpy.array(
+                [-2 * self.plate_intercept + self.member.L + self.inline_weld_toe.L, self.plate.T, self.opline_weld.L / 2])
+            weldHR21_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHR21_wDir = numpy.array([-1.0, 0.0, 0.0])
+            self.weldHR21.place(weldHR21OriginL, weldHR21_uDir, weldHR21_wDir)
+            self.weldHR21_Model = self.weldHR21.create_model()
+
+            weldHR22OriginL = numpy.array(
+                [-2 * self.plate_intercept + self.member.L, self.plate.T, -self.opline_weld.L / 2])
+            weldHR22_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHR22_wDir = numpy.array([1.0, 0.0, 0.0])
+            self.weldHR22.place(weldHR22OriginL, weldHR22_uDir, weldHR22_wDir)
+            self.weldHR22_Model = self.weldHR22.create_model()
+
+            weldVL21OriginL = numpy.array([-self.plate_intercept, self.plate.T, self.opline_weld.L / 2])
+            weldVL21_uDir = numpy.array([-1.0, 0.0, 0.0])
+            weldVL21_wDir = numpy.array([0.0, 0.0, -1.0])
+            self.weldVL21.place(weldVL21OriginL, weldVL21_uDir, weldVL21_wDir)
+            self.weldVL21_Model = self.weldVL21.create_model()
+
+            weldVR21OriginL = numpy.array(
+                [-self.plate_intercept + self.member.L, self.plate.T, -self.opline_weld.L / 2])
+            weldVR21_uDir = numpy.array([1.0, 0.0, 0.0])
+            weldVR21_wDir = numpy.array([0.0, 0.0, 1.0])
+            self.weldVR21.place(weldVR21OriginL, weldVR21_uDir, weldVR21_wDir)
             self.weldVR21_Model = self.weldVR21.create_model()
 
         elif self.Obj.sec_profile == 'Star Angles':
@@ -266,84 +406,74 @@ class TensionAngleWeldCAD(object):
             weldHL11_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHL11_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHL11.place(weldHL11OriginL, weldHL11_uDir, weldHL11_wDir)
-
             self.weldHL11_Model = self.weldHL11.create_model()
 
-            weldHL12OriginL = numpy.array([0.0, 0.0, -self.opline_weld.L])
-            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0])
-            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0])
+            weldHL12OriginL = numpy.array([-self.plate_intercept + self.inline_weld_toe.L, 0.0, -self.opline_weld.L])
+            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0]) # was [0.0, 0.0, -1.0]
+            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0]) # was [-1.0, 0.0, 0.0]
             self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
-
             self.weldHL12_Model = self.weldHL12.create_model()
 
-            weldHR11OriginL = numpy.array([-2 * self.plate_intercept + self.member.L, 0.0, 0.0])
-            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0])
-            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0])
+            weldHR11OriginL = numpy.array([-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, 0.0])
+            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0]) # was [0.0, 0.0, 1.0]
+            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0]) # was [1.0, 0.0, 0.0]
             self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
-
             self.weldHR11_Model = self.weldHR11.create_model()
 
             weldHR12OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, -self.opline_weld.L])
             weldHR12_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHR12_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHR12.place(weldHR12OriginL, weldHR12_uDir, weldHR12_wDir)
-
             self.weldHR12_Model = self.weldHR12.create_model()
 
             weldVL11OriginL = numpy.array([-self.plate_intercept, 0.0, -self.opline_weld.L])
             weldVL11_uDir = numpy.array([-1.0, 0.0, 0.0])
             weldVL11_wDir = numpy.array([0.0, 0.0, 1.0])
             self.weldVL11.place(weldVL11OriginL, weldVL11_uDir, weldVL11_wDir)
-
             self.weldVL11_Model = self.weldVL11.create_model()
 
             weldVR11OriginL = numpy.array([-self.plate_intercept + self.member.L, 0.0, 0.0])
             weldVR11_uDir = numpy.array([1.0, 0.0, 0.0])
             weldVR11_wDir = numpy.array([0.0, 0.0, -1.0])
             self.weldVR11.place(weldVR11OriginL, weldVR11_uDir, weldVR11_wDir)
-
             self.weldVR11_Model = self.weldVR11.create_model()
 
-            weldHL21OriginL = numpy.array([0.0, self.plate.T, self.opline_weld.L])
+            weldHL21OriginL = numpy.array(
+                [-self.plate_intercept + self.inline_weld_toe.L, self.plate.T + self.inline_weld_toe.h, self.opline_weld.L])
             weldHL21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHL21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL21.place(weldHL21OriginL, weldHL21_uDir, weldHL21_wDir)
-
             self.weldHL21_Model = self.weldHL21.create_model()
 
-            weldHL22OriginL = numpy.array([- self.plate_intercept, self.plate.T, 0.0])
+            weldHL22OriginL = numpy.array([-self.plate_intercept, self.plate.T, 0.0])
             weldHL22_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHL22_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHL22.place(weldHL22OriginL, weldHL22_uDir, weldHL22_wDir)
-
             self.weldHL22_Model = self.weldHL22.create_model()
 
-            weldHR21OriginL = numpy.array([-self.plate_intercept + self.member.L, self.plate.T, self.opline_weld.L])
+            weldHR21OriginL = numpy.array(
+                [-self.plate_intercept + self.member.L, self.plate.T + self.inline_weld_toe.h, self.opline_weld.L])
             weldHR21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHR21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHR21.place(weldHR21OriginL, weldHR21_uDir, weldHR21_wDir)
-
             self.weldHR21_Model = self.weldHR21.create_model()
 
-            weldHR22OriginL = numpy.array([-2 * self.plate_intercept + self.member.L, self.plate.T, 0.0])
+            weldHR22OriginL = numpy.array([-self.plate_intercept + self.member.L - self.inline_weld_heel.L, self.plate.T, 0.0])
             weldHR22_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHR22_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR22.place(weldHR22OriginL, weldHR22_uDir, weldHR22_wDir)
-
             self.weldHR22_Model = self.weldHR22.create_model()
 
             weldVL21OriginL = numpy.array([-self.plate_intercept, self.plate.T, self.opline_weld.L])
             weldVL21_uDir = numpy.array([-1.0, 0.0, 0.0])
             weldVL21_wDir = numpy.array([0.0, 0.0, -1.0])
             self.weldVL21.place(weldVL21OriginL, weldVL21_uDir, weldVL21_wDir)
-
             self.weldVL21_Model = self.weldVL21.create_model()
 
             weldVR21OriginL = numpy.array([-self.plate_intercept + self.member.L, self.plate.T, 0.0])
             weldVR21_uDir = numpy.array([1.0, 0.0, 0.0])
             weldVR21_wDir = numpy.array([0.0, 0.0, 1.0])
             self.weldVR21.place(weldVR21OriginL, weldVR21_uDir, weldVR21_wDir)
-
             self.weldVR21_Model = self.weldVR21.create_model()
 
 

--- a/src/osdag_core/cad/Tension/WeldedCAD.py
+++ b/src/osdag_core/cad/Tension/WeldedCAD.py
@@ -12,7 +12,9 @@ import copy
 from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Fuse
 
 class TensionAngleWeldCAD(object):
-    def __init__(self, Obj, member, plate, inline_weld_toe, inline_weld_heel, opline_weld, weld_plate_array):
+
+    def __init__(self, Obj, member, plate, inline_weld_toe, inline_weld_heel,
+                 opline_weld, weld_plate_array):
 
         self.Obj = Obj
         self.member = member
@@ -27,25 +29,23 @@ class TensionAngleWeldCAD(object):
         self.member1 = copy.deepcopy(self.member)
         self.member2 = copy.deepcopy(self.member)
 
-        self.weldHL11 = copy.deepcopy(self.inline_weld_toe)
+        self.weldHL11 = copy.deepcopy(self.inline_weld_heel)
         self.weldHL12 = copy.deepcopy(self.inline_weld_toe)
         self.weldHR11 = copy.deepcopy(self.inline_weld_heel)
-        self.weldHR12 = copy.deepcopy(self.inline_weld_heel)
-
+        self.weldHR12 = copy.deepcopy(self.inline_weld_toe)
         self.weldVL11 = copy.deepcopy(self.opline_weld)
         self.weldVR11 = copy.deepcopy(self.opline_weld)
 
-        # back side member (B2B / Star)
-        self.weldHL21 = copy.deepcopy(self.inline_weld_toe)
+        self.weldHL21 = copy.deepcopy(self.inline_weld_heel)
         self.weldHL22 = copy.deepcopy(self.inline_weld_toe)
         self.weldHR21 = copy.deepcopy(self.inline_weld_heel)
-        self.weldHR22 = copy.deepcopy(self.inline_weld_heel)
+        self.weldHR22 = copy.deepcopy(self.inline_weld_toe)
 
         self.weldVL21 = copy.deepcopy(self.opline_weld)
         self.weldVR21 = copy.deepcopy(self.opline_weld)
 
-        self.s = max(15, self.inline_weld_toe.h)  # size unchanged, use either — both share weld.size
-        self.plate_intercept = self.plate.L - self.s - 50
+        self.s = max(15, self.inline_weld_toe.h)
+        self.plate_intercept = self.inline_weld_heel.L
         self.inter_length = self.member.L - 2 * (self.plate.L - 50)
 
     def create_3DModel(self):
@@ -173,15 +173,14 @@ class TensionAngleWeldCAD(object):
             self.weldHL11_Model = self.weldHL11.create_model()
 
             weldHL12OriginL = numpy.array([-self.plate_intercept + self.inline_weld_toe.L, 0.0, -self.opline_weld.L / 2])
-            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0]) # was [0.0, 0.0, -1.0]
-            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0]) # was [-1.0, 0.0, 0.0]
+            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
             self.weldHL12_Model = self.weldHL12.create_model()
 
-            weldHR11OriginL = numpy.array(
-                [-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
-            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0]) # was [0.0, 0.0, 1.0]
-            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0]) # was [1.0, 0.0, 0.0]
+            weldHR11OriginL = numpy.array([-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
+            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
             self.weldHR11_Model = self.weldHR11.create_model()
 
@@ -212,15 +211,14 @@ class TensionAngleWeldCAD(object):
             self.weldHL11_Model = self.weldHL11.create_model()
 
             weldHL12OriginL = numpy.array([-self.plate_intercept + self.inline_weld_toe.L, 0.0, -self.opline_weld.L / 2])
-            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0]) # was [0.0, 0.0, -1.0]
-            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0]) # was [-1.0, 0.0, 0.0]
+            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
             self.weldHL12_Model = self.weldHL12.create_model()
 
-            weldHR11OriginL = numpy.array(
-                [-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
-            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0]) # was [0.0, 0.0, 1.0]
-            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0]) # was [1.0, 0.0, 0.0]
+            weldHR11OriginL = numpy.array([-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
+            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
             self.weldHR11_Model = self.weldHR11.create_model()
 
@@ -251,15 +249,14 @@ class TensionAngleWeldCAD(object):
             self.weldHL11_Model = self.weldHL11.create_model()
 
             weldHL12OriginL = numpy.array([-self.plate_intercept + self.inline_weld_toe.L, 0.0, -self.opline_weld.L / 2])
-            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0]) # was [0.0, 0.0, -1.0]
-            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0]) # was [-1.0, 0.0, 0.0]
+            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
             self.weldHL12_Model = self.weldHL12.create_model()
 
-            weldHR11OriginL = numpy.array(
-                [-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
-            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0]) # was [0.0, 0.0, 1.0]
-            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0]) # was [1.0, 0.0, 0.0]
+            weldHR11OriginL = numpy.array([-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
+            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
             self.weldHR11_Model = self.weldHR11.create_model()
 
@@ -281,8 +278,7 @@ class TensionAngleWeldCAD(object):
             self.weldVR11.place(weldVR11OriginL, weldVR11_uDir, weldVR11_wDir)
             self.weldVR11_Model = self.weldVR11.create_model()
 
-            weldHL21OriginL = numpy.array(
-                [-self.plate_intercept + self.inline_weld_toe.L, self.plate.T, self.opline_weld.L / 2])
+            weldHL21OriginL = numpy.array([-self.plate_intercept + self.inline_weld_heel.L, self.plate.T,  self.opline_weld.L / 2])
             weldHL21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHL21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL21.place(weldHL21OriginL, weldHL21_uDir, weldHL21_wDir)
@@ -294,15 +290,13 @@ class TensionAngleWeldCAD(object):
             self.weldHL22.place(weldHL22OriginL, weldHL22_uDir, weldHL22_wDir)
             self.weldHL22_Model = self.weldHL22.create_model()
 
-            weldHR21OriginL = numpy.array(
-                [-self.plate_intercept + self.member.L, self.plate.T, self.opline_weld.L / 2])
+            weldHR21OriginL = numpy.array([-self.plate_intercept + self.member.L, self.plate.T, self.opline_weld.L / 2])
             weldHR21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHR21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHR21.place(weldHR21OriginL, weldHR21_uDir, weldHR21_wDir)
             self.weldHR21_Model = self.weldHR21.create_model()
 
-            weldHR22OriginL = numpy.array(
-                [-self.plate_intercept + self.member.L - self.inline_weld_heel.L, self.plate.T, -self.opline_weld.L / 2])
+            weldHR22OriginL = numpy.array([-self.plate_intercept + self.member.L - self.inline_weld_toe.L, self.plate.T, -self.opline_weld.L / 2])
             weldHR22_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHR22_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR22.place(weldHR22OriginL, weldHR22_uDir, weldHR22_wDir)
@@ -314,8 +308,7 @@ class TensionAngleWeldCAD(object):
             self.weldVL21.place(weldVL21OriginL, weldVL21_uDir, weldVL21_wDir)
             self.weldVL21_Model = self.weldVL21.create_model()
 
-            weldVR21OriginL = numpy.array(
-                [-self.plate_intercept + self.member.L, self.plate.T, -self.opline_weld.L / 2])
+            weldVR21OriginL = numpy.array([-self.plate_intercept + self.member.L, self.plate.T, -self.opline_weld.L / 2])
             weldVR21_uDir = numpy.array([1.0, 0.0, 0.0])
             weldVR21_wDir = numpy.array([0.0, 0.0, 1.0])
             self.weldVR21.place(weldVR21OriginL, weldVR21_uDir, weldVR21_wDir)
@@ -330,15 +323,14 @@ class TensionAngleWeldCAD(object):
             self.weldHL11_Model = self.weldHL11.create_model()
 
             weldHL12OriginL = numpy.array([-self.plate_intercept + self.inline_weld_toe.L, 0.0, -self.opline_weld.L / 2])
-            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0]) # was [0.0, 0.0, -1.0]
-            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0]) # was [-1.0, 0.0, 0.0]
+            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
             self.weldHL12_Model = self.weldHL12.create_model()
 
-            weldHR11OriginL = numpy.array(
-                [-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
-            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0]) # was [0.0, 0.0, 1.0]
-            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0]) # was [1.0, 0.0, 0.0]
+            weldHR11OriginL = numpy.array([-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, self.opline_weld.L / 2])
+            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
             self.weldHR11_Model = self.weldHR11.create_model()
 
@@ -360,8 +352,7 @@ class TensionAngleWeldCAD(object):
             self.weldVR11.place(weldVR11OriginL, weldVR11_uDir, weldVR11_wDir)
             self.weldVR11_Model = self.weldVR11.create_model()
 
-            weldHL21OriginL = numpy.array(
-                [-self.plate_intercept + self.inline_weld_heel.L, self.plate.T, self.opline_weld.L / 2])
+            weldHL21OriginL = numpy.array([-self.plate_intercept + self.inline_weld_heel.L, self.plate.T, self.opline_weld.L / 2])
             weldHL21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHL21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL21.place(weldHL21OriginL, weldHL21_uDir, weldHL21_wDir)
@@ -373,15 +364,13 @@ class TensionAngleWeldCAD(object):
             self.weldHL22.place(weldHL22OriginL, weldHL22_uDir, weldHL22_wDir)
             self.weldHL22_Model = self.weldHL22.create_model()
 
-            weldHR21OriginL = numpy.array(
-                [-2 * self.plate_intercept + self.member.L + self.inline_weld_toe.L, self.plate.T, self.opline_weld.L / 2])
+            weldHR21OriginL = numpy.array([-2 * self.plate_intercept + self.member.L + self.inline_weld_toe.L, self.plate.T, self.opline_weld.L / 2])
             weldHR21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHR21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHR21.place(weldHR21OriginL, weldHR21_uDir, weldHR21_wDir)
             self.weldHR21_Model = self.weldHR21.create_model()
 
-            weldHR22OriginL = numpy.array(
-                [-2 * self.plate_intercept + self.member.L, self.plate.T, -self.opline_weld.L / 2])
+            weldHR22OriginL = numpy.array([-2 * self.plate_intercept + self.member.L, self.plate.T, -self.opline_weld.L / 2])
             weldHR22_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHR22_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR22.place(weldHR22OriginL, weldHR22_uDir, weldHR22_wDir)
@@ -393,8 +382,7 @@ class TensionAngleWeldCAD(object):
             self.weldVL21.place(weldVL21OriginL, weldVL21_uDir, weldVL21_wDir)
             self.weldVL21_Model = self.weldVL21.create_model()
 
-            weldVR21OriginL = numpy.array(
-                [-self.plate_intercept + self.member.L, self.plate.T, -self.opline_weld.L / 2])
+            weldVR21OriginL = numpy.array([-self.plate_intercept + self.member.L, self.plate.T, -self.opline_weld.L / 2])
             weldVR21_uDir = numpy.array([1.0, 0.0, 0.0])
             weldVR21_wDir = numpy.array([0.0, 0.0, 1.0])
             self.weldVR21.place(weldVR21OriginL, weldVR21_uDir, weldVR21_wDir)
@@ -409,14 +397,14 @@ class TensionAngleWeldCAD(object):
             self.weldHL11_Model = self.weldHL11.create_model()
 
             weldHL12OriginL = numpy.array([-self.plate_intercept + self.inline_weld_toe.L, 0.0, -self.opline_weld.L])
-            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0]) # was [0.0, 0.0, -1.0]
-            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0]) # was [-1.0, 0.0, 0.0]
+            weldHL12_uDir = numpy.array([0.0, 0.0, -1.0])
+            weldHL12_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL12.place(weldHL12OriginL, weldHL12_uDir, weldHL12_wDir)
             self.weldHL12_Model = self.weldHL12.create_model()
 
             weldHR11OriginL = numpy.array([-self.plate_intercept + self.member.L - self.inline_weld_heel.L, 0.0, 0.0])
-            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0]) # was [0.0, 0.0, 1.0]
-            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0]) # was [1.0, 0.0, 0.0]
+            weldHR11_uDir = numpy.array([0.0, 0.0, 1.0])
+            weldHR11_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR11.place(weldHR11OriginL, weldHR11_uDir, weldHR11_wDir)
             self.weldHR11_Model = self.weldHR11.create_model()
 
@@ -438,27 +426,25 @@ class TensionAngleWeldCAD(object):
             self.weldVR11.place(weldVR11OriginL, weldVR11_uDir, weldVR11_wDir)
             self.weldVR11_Model = self.weldVR11.create_model()
 
-            weldHL21OriginL = numpy.array(
-                [-self.plate_intercept + self.inline_weld_toe.L, self.plate.T + self.inline_weld_toe.h, self.opline_weld.L])
+            weldHL21OriginL = numpy.array([-self.plate_intercept + self.inline_weld_heel.L, self.plate.T + self.inline_weld_toe.h, self.opline_weld.L])
             weldHL21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHL21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHL21.place(weldHL21OriginL, weldHL21_uDir, weldHL21_wDir)
             self.weldHL21_Model = self.weldHL21.create_model()
 
-            weldHL22OriginL = numpy.array([-self.plate_intercept, self.plate.T, 0.0])
+            weldHL22OriginL = numpy.array([-self.plate_intercept , self.plate.T, 0.0])
             weldHL22_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHL22_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHL22.place(weldHL22OriginL, weldHL22_uDir, weldHL22_wDir)
             self.weldHL22_Model = self.weldHL22.create_model()
 
-            weldHR21OriginL = numpy.array(
-                [-self.plate_intercept + self.member.L, self.plate.T + self.inline_weld_toe.h, self.opline_weld.L])
+            weldHR21OriginL = numpy.array([-self.plate_intercept + self.member.L, self.plate.T + self.inline_weld_toe.h, self.opline_weld.L])
             weldHR21_uDir = numpy.array([0.0, 0.0, 1.0])
             weldHR21_wDir = numpy.array([-1.0, 0.0, 0.0])
             self.weldHR21.place(weldHR21OriginL, weldHR21_uDir, weldHR21_wDir)
             self.weldHR21_Model = self.weldHR21.create_model()
 
-            weldHR22OriginL = numpy.array([-self.plate_intercept + self.member.L - self.inline_weld_heel.L, self.plate.T, 0.0])
+            weldHR22OriginL = numpy.array([-self.plate_intercept + self.member.L - self.inline_weld_toe.L, self.plate.T, 0.0])
             weldHR22_uDir = numpy.array([0.0, 0.0, -1.0])
             weldHR22_wDir = numpy.array([1.0, 0.0, 0.0])
             self.weldHR22.place(weldHR22OriginL, weldHR22_uDir, weldHR22_wDir)

--- a/src/osdag_core/cad/common_logic.py
+++ b/src/osdag_core/cad/common_logic.py
@@ -1768,101 +1768,146 @@ class CommonDesignLogic(object):
         return basePlate
 
     def createTensionCAD(self):
-        """
-        :return: The calculated values/parameters to create 3D CAD model of individual components.
-        """
+
         T = self.module_object
 
-        # Types of connections =  #'Angles', 'Back to Back Angles', 'Star Angles', 'Channels', 'Back to Back Channels'
         if self.connection == KEY_DISP_TENSION_BOLTED:
-            bolt_d = float(T.bolt.bolt_diameter_provided)  # Bolt diameter (shank part), entered by user
-            bolt_r = bolt_d / 2  # Bolt radius (Shank part)
-            bolt_T = self.boltHeadThick_Calculation(bolt_d)  # Bolt head thickness
-            bolt_R = self.boltHeadDia_Calculation(bolt_d) / 2  # Bolt head diameter (Hexagon)
-            bolt_Ht = self.boltLength_Calculation(bolt_d)  # Bolt head height
+            bolt_d = float(T.bolt.bolt_diameter_provided)
+            bolt_r = bolt_d / 2
+            bolt_T = self.boltHeadThick_Calculation(bolt_d)
+            bolt_R = self.boltHeadDia_Calculation(bolt_d) / 2
+            bolt_Ht = self.boltLength_Calculation(bolt_d)
 
-            bolt = Bolt(R=bolt_R, T=bolt_T, H=bolt_Ht, r=bolt_r)  # Call to create Bolt from Component directory
-            nut_T = self.nutThick_Calculation(bolt_d)  # Nut thickness, usually nut thickness = nut height
+            bolt = Bolt(R=bolt_R, T=bolt_T, H=bolt_Ht, r=bolt_r)
+            nut_T = self.nutThick_Calculation(bolt_d)
             nut_Ht = nut_T
-            nut = Nut(R=bolt_R, T=nut_T, H=nut_Ht, innerR1=bolt_r)  # Call to create Nut from Component directory
+            nut = Nut(R=bolt_R, T=nut_T, H=nut_Ht, innerR1=bolt_r)
 
-            plate = GassetPlate(L=float(T.plate.length + 50), H=float(T.plate.height),
-                                T=float(T.plate.thickness_provided), degree=30)
-            intermittentPlates = Plate(L=float(T.inter_plate_height), W=float(T.inter_plate_length), T=float(plate.T))
+            plate = GassetPlate(L=float(T.plate.length + 50),
+                                H=float(T.plate.height),
+                                T=float(T.plate.thickness_provided),
+                                degree=30)
+            intermittentPlates = Plate(L=float(T.inter_plate_height),
+                                       W=float(T.inter_plate_length),
+                                       T=float(plate.T))
 
-
-            if T.sec_profile == 'Channels' or T.sec_profile == 'Back to Back Channels':
-                member = Channel(B=float(T.section_size_1.flange_width), T=float(T.section_size_1.flange_thickness),
-                                 D=float(T.section_size_1.depth), t=float(T.section_size_1.web_thickness),
-                                 R1=float(T.section_size_1.root_radius), R2=float(T.section_size_1.toe_radius),
+            if T.sec_profile in ('Channels', 'Back to Back Channels'):
+                member = Channel(B=float(T.section_size_1.flange_width),
+                                 T=float(T.section_size_1.flange_thickness),
+                                 D=float(T.section_size_1.depth),
+                                 t=float(T.section_size_1.web_thickness),
+                                 R1=float(T.section_size_1.root_radius),
+                                 R2=float(T.section_size_1.toe_radius),
                                  L=float(T.length))
                 if T.sec_profile == 'Channels':
-                    nut_space = member.t + plate.T + nut.T  # member.T + plate.T + nut.T
-
+                    nut_space = member.t + plate.T + nut.T
                 else:
-                    nut_space = 2 * member.t + plate.T + nut.T  # 2*member.T + plate.T + nut.T
+                    nut_space = 2 * member.t + plate.T + nut.T
 
-                intermittentConnection = IntermittentNutBoltPlateArray(T, nut, bolt, intermittentPlates, nut_space)
+                intermittentConnection = IntermittentNutBoltPlateArray(
+                    T, nut, bolt, intermittentPlates, nut_space)
                 nut_bolt_array = TNutBoltArray(T, nut, bolt, nut_space)
-                tensionCAD = TensionChannelBoltCAD(T, member, plate, nut_bolt_array, intermittentConnection)
+                tensionCAD = TensionChannelBoltCAD(
+                    T, member, plate, nut_bolt_array, intermittentConnection)
 
             else:
-                member = Angle(L=float(T.length), A=float(T.section_size_1.max_leg), B=float(T.section_size_1.min_leg),
-                               T=float(T.section_size_1.thickness), R1=float(T.section_size_1.root_radius),
+                member = Angle(L=float(T.length),
+                               A=float(T.section_size_1.max_leg),
+                               B=float(T.section_size_1.min_leg),
+                               T=float(T.section_size_1.thickness),
+                               R1=float(T.section_size_1.root_radius),
                                R2=float(T.section_size_1.toe_radius))
                 if T.sec_profile == 'Back to Back Angles':
                     nut_space = 2 * member.T + plate.T + nut.T
                 else:
                     nut_space = member.T + plate.T + nut.T
 
-                intermittentConnection = IntermittentNutBoltPlateArray(T, nut, bolt, intermittentPlates, nut_space)
+                intermittentConnection = IntermittentNutBoltPlateArray(
+                    T, nut, bolt, intermittentPlates, nut_space)
                 nut_bolt_array = TNutBoltArray(T, nut, bolt, nut_space)
-                tensionCAD = TensionAngleBoltCAD(T, member, plate, nut_bolt_array, intermittentConnection)
+                tensionCAD = TensionAngleBoltCAD(
+                    T, member, plate, nut_bolt_array, intermittentConnection)
 
+        # WELDED
         else:
-            plate = GassetPlate(L=float(T.plate.length + 50), H=float(T.plate.height),
-                                T=float(T.plate.thickness_provided), degree=30)
+            # Gusset plate — 50 mm extra length accounts for the tapered nose
+            plate = GassetPlate(L=float(T.plate.length + 50),
+                                H=float(T.plate.height),
+                                T=float(T.plate.thickness_provided),
+                                degree=30)
 
-            intermittentPlates = Plate(L=float(T.inter_plate_height), W=float(T.inter_plate_length), T=plate.T)
-            intermittentWelds = FilletWeld(h=float(T.inter_weld_size), b=float(T.inter_weld_size), L=intermittentPlates.W)
-            weld_plate_array = IntermittentWelds(T, intermittentWelds, intermittentPlates)
+            intermittentPlates = Plate(L=float(T.inter_plate_height),
+                                       W=float(T.inter_plate_length),
+                                       T=plate.T)
+            intermittentWelds = FilletWeld(h=float(T.inter_weld_size),
+                                           b=float(T.inter_weld_size),
+                                           L=intermittentPlates.W)
+            weld_plate_array = IntermittentWelds(T, intermittentWelds,
+                                                 intermittentPlates)
 
             s = max(15, float(T.weld.size))
             plate_intercept = plate.L - s - 50
-            if T.sec_profile == 'Channels' or T.sec_profile == 'Back to Back Channels':
-                member = Channel(B=float(T.section_size_1.flange_width), T=float(T.section_size_1.flange_thickness),
-                                 D=float(T.section_size_1.depth), t=float(T.section_size_1.web_thickness),
-                                 R1=float(T.section_size_1.root_radius), R2=float(T.section_size_1.toe_radius),
+
+            # Channel section (single or Back-to-Back)
+            if T.sec_profile in ('Channels', 'Back to Back Channels'):
+                member = Channel(B=float(T.section_size_1.flange_width),
+                                 T=float(T.section_size_1.flange_thickness),
+                                 D=float(T.section_size_1.depth),
+                                 t=float(T.section_size_1.web_thickness),
+                                 R1=float(T.section_size_1.root_radius),
+                                 R2=float(T.section_size_1.toe_radius),
                                  L=float(T.length))
 
-                # Asymmetric flange weld
-                inline_weld_toe = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(plate_intercept))
-                inline_weld_heel = inline_weld_toe  # symmetric for channels
-                opline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(member.D))
+                # For channels, both flange welds are equal in length.
+                inline_weld_toe = FilletWeld(b=float(T.weld.size),
+                                             h=float(T.weld.size),
+                                             L=float(T.flange_weld_toe))
+                inline_weld_heel = FilletWeld(b=float(T.weld.size),
+                                              h=float(T.weld.size),
+                                              L=float(T.flange_weld_heel))
 
-                tensionCAD = TensionChannelWeldCAD(T, member, plate, inline_weld_toe, inline_weld_heel, opline_weld,
-                                                   weld_plate_array)
+                opline_weld = FilletWeld(b=float(T.weld.size),
+                                         h=float(T.weld.size),
+                                         L=float(member.D))
 
+                tensionCAD = TensionChannelWeldCAD(
+                    T, member, plate,
+                    inline_weld_toe, inline_weld_heel, opline_weld,
+                    weld_plate_array)
+
+            # Angle section (Single, Back-to-Back, or Star)
             else:
-                member = Angle(L=float(T.length), A=float(T.section_size_1.max_leg), B=float(T.section_size_1.min_leg),
-                               T=float(T.section_size_1.thickness), R1=float(T.section_size_1.root_radius),
+                member = Angle(L=float(T.length),
+                               A=float(T.section_size_1.max_leg),
+                               B=float(T.section_size_1.min_leg),
+                               T=float(T.section_size_1.thickness),
+                               R1=float(T.section_size_1.root_radius),
                                R2=float(T.section_size_1.toe_radius))
 
-                # Asymmetric flange welds — toe (away from centroid) is longer
-                inline_weld_toe = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(T.flange_weld_toe))
-                inline_weld_heel = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(T.flange_weld_heel))
+                inline_weld_toe = FilletWeld(b=float(T.weld.size),
+                                             h=float(T.weld.size),
+                                             L=float(T.flange_weld_toe))
+
+                inline_weld_heel = FilletWeld(b=float(T.weld.size),
+                                              h=float(T.weld.size),
+                                              L=float(T.flange_weld_heel))
 
                 if T.loc == 'Long Leg':
-                    opline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(member.A))
+                    opline_weld = FilletWeld(b=float(T.weld.size),
+                                             h=float(T.weld.size),
+                                             L=float(member.A))  # max_leg
                 else:
-                    opline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(member.B))
+                    opline_weld = FilletWeld(b=float(T.weld.size),
+                                             h=float(T.weld.size),
+                                             L=float(member.B))  # min_leg
 
-                tensionCAD = TensionAngleWeldCAD(T, member, plate, inline_weld_toe, inline_weld_heel, opline_weld,
-                                                 weld_plate_array)
+                tensionCAD = TensionAngleWeldCAD(
+                    T, member, plate,
+                    inline_weld_toe, inline_weld_heel, opline_weld,
+                    weld_plate_array)
 
         tensionCAD.create_3DModel()
 
-        # Register model shapes with memory manager to prevent premature GC
         if hasattr(tensionCAD, 'get_models'):
             self._register_shapes(tensionCAD.get_models())
 
@@ -2801,12 +2846,16 @@ class CommonDesignLogic(object):
         plate = GassetPlate(L=float(T.plate.length + 50), H=float(T.plate.height),
                             T=float(T.plate.thickness_provided), degree=30)
 
-        intermittentPlates = Plate(L=float(getattr(T, 'inter_plate_height', 0.0)), W=float(getattr(T, 'inter_plate_length', 0.0)), T=plate.T)
-        intermittentWelds = FilletWeld(h=float(getattr(T, 'inter_weld_size', 0.0)), b=float(getattr(T, 'inter_weld_size', 0.0)), L=intermittentPlates.W)
+        intermittentPlates = Plate(L=float(getattr(T, 'inter_plate_height', 0.0)),
+                                   W=float(getattr(T, 'inter_plate_length', 0.0)),
+                                   T=plate.T)
+        intermittentWelds = FilletWeld(h=float(getattr(T, 'inter_weld_size', 0.0)),
+                                       b=float(getattr(T, 'inter_weld_size', 0.0)),
+                                       L=intermittentPlates.W)
         if not hasattr(T, 'inter_memb_length'):
             T.inter_memb_length = 0.0
         if not hasattr(T, 'inter_conn'):
-            T.inter_conn = "0" 
+            T.inter_conn = "0"
         # Alias section_size_1 -> section_property for compatibility with IntermittentWelds
         if not hasattr(T, 'section_size_1') and hasattr(T, 'section_property'):
             T.section_size_1 = T.section_property
@@ -2816,32 +2865,61 @@ class CommonDesignLogic(object):
                 T.section_size_1.depth = T.section_size_1.max_leg
         weld_plate_array = IntermittentWelds(T, intermittentWelds, intermittentPlates)
 
-        s = max(15, float(T.weld.size))
-        plate_intercept = plate.L - s - 50
-        print(f"DEBUG createStrutWeldedCAD: sec_profile = '{T.sec_profile}', section_property type = {type(T.section_property).__name__}")
-        if T.sec_profile == 'Channels' or T.sec_profile == 'Back to Back Channels':
-            member = Channel(B=float(T.section_property.flange_width), T=float(T.section_property.flange_thickness),
-                             D=float(T.section_property.depth), t=float(T.section_property.web_thickness),
-                             R1=float(T.section_property.root_radius), R2=float(T.section_property.toe_radius),
+        print(
+            f"DEBUG createStrutWeldedCAD: sec_profile = '{T.sec_profile}', section_property type = {type(T.section_property).__name__}")
+
+        if 'Channels' in T.sec_profile:
+            member = Channel(B=float(T.section_property.flange_width),
+                             T=float(T.section_property.flange_thickness),
+                             D=float(T.section_property.depth),
+                             t=float(T.section_property.web_thickness),
+                             R1=float(T.section_property.root_radius),
+                             R2=float(T.section_property.toe_radius),
                              L=float(T.length))
-            inline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(plate_intercept))
-            opline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(member.D))
 
+            inline_weld_toe = FilletWeld(b=float(T.weld.size),
+                                         h=float(T.weld.size),
+                                         L=float(T.flange_weld_toe))
+            inline_weld_heel = FilletWeld(b=float(T.weld.size),
+                                          h=float(T.weld.size),
+                                          L=float(T.flange_weld_heel))
 
-            strutCAD = StrutChannelWeldCAD(T, member, plate, inline_weld, opline_weld, weld_plate_array)
+            opline_weld = FilletWeld(b=float(T.weld.size),
+                                     h=float(T.weld.size),
+                                     L=float(member.D))
+
+            strutCAD = StrutChannelWeldCAD(T, member, plate,
+                                           inline_weld_toe, inline_weld_heel,
+                                           opline_weld, weld_plate_array)
 
         else:
-            member = Angle(L=float(T.length), A=float(T.section_property.max_leg), B=float(T.section_property.min_leg),
-                           T=float(T.section_property.thickness), R1=float(T.section_property.root_radius),
+            member = Angle(L=float(T.length),
+                           A=float(T.section_property.max_leg),
+                           B=float(T.section_property.min_leg),
+                           T=float(T.section_property.thickness),
+                           R1=float(T.section_property.root_radius),
                            R2=float(T.section_property.toe_radius))
-            inline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(plate_intercept))
-            if T.loc == 'Long Leg':
-                opline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(member.A))
-            else:  # 'Short Leg'
-                opline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(member.B))
 
-            # weld_plate_array = IntermittentWelds(T, intermittentWelds, intermittentPlates)
-            strutCAD = StrutAngleWeldCAD(T, member, plate, inline_weld, opline_weld, weld_plate_array)
+            inline_weld_toe = FilletWeld(b=float(T.weld.size),
+                                         h=float(T.weld.size),
+                                         L=float(T.flange_weld_toe))
+
+            inline_weld_heel = FilletWeld(b=float(T.weld.size),
+                                          h=float(T.weld.size),
+                                          L=float(T.flange_weld_heel))
+
+            if T.loc == 'Long Leg':
+                opline_weld = FilletWeld(b=float(T.weld.size),
+                                         h=float(T.weld.size),
+                                         L=float(member.A))
+            else:  # 'Short Leg'
+                opline_weld = FilletWeld(b=float(T.weld.size),
+                                         h=float(T.weld.size),
+                                         L=float(member.B))
+
+            strutCAD = StrutAngleWeldCAD(T, member, plate,
+                                         inline_weld_toe, inline_weld_heel,
+                                         opline_weld, weld_plate_array)
 
         strutCAD.create_3DModel()
 

--- a/src/osdag_core/cad/common_logic.py
+++ b/src/osdag_core/cad/common_logic.py
@@ -1834,24 +1834,31 @@ class CommonDesignLogic(object):
                                  D=float(T.section_size_1.depth), t=float(T.section_size_1.web_thickness),
                                  R1=float(T.section_size_1.root_radius), R2=float(T.section_size_1.toe_radius),
                                  L=float(T.length))
-                inline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(plate_intercept))
+
+                # Asymmetric flange weld
+                inline_weld_toe = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(plate_intercept))
+                inline_weld_heel = inline_weld_toe  # symmetric for channels
                 opline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(member.D))
 
-
-                tensionCAD = TensionChannelWeldCAD(T, member, plate, inline_weld, opline_weld, weld_plate_array)
+                tensionCAD = TensionChannelWeldCAD(T, member, plate, inline_weld_toe, inline_weld_heel, opline_weld,
+                                                   weld_plate_array)
 
             else:
                 member = Angle(L=float(T.length), A=float(T.section_size_1.max_leg), B=float(T.section_size_1.min_leg),
                                T=float(T.section_size_1.thickness), R1=float(T.section_size_1.root_radius),
                                R2=float(T.section_size_1.toe_radius))
-                inline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(plate_intercept))
+
+                # Asymmetric flange welds — toe (away from centroid) is longer
+                inline_weld_toe = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(T.flange_weld_toe))
+                inline_weld_heel = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(T.flange_weld_heel))
+
                 if T.loc == 'Long Leg':
                     opline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(member.A))
-                else:  # 'Short Leg'
+                else:
                     opline_weld = FilletWeld(b=float(T.weld.size), h=float(T.weld.size), L=float(member.B))
 
-                # weld_plate_array = IntermittentWelds(T, intermittentWelds, intermittentPlates)
-                tensionCAD = TensionAngleWeldCAD(T, member, plate, inline_weld, opline_weld, weld_plate_array)
+                tensionCAD = TensionAngleWeldCAD(T, member, plate, inline_weld_toe, inline_weld_heel, opline_weld,
+                                                 weld_plate_array)
 
         tensionCAD.create_3DModel()
 

--- a/src/osdag_core/design_type/compression_member/compression_welded.py
+++ b/src/osdag_core/design_type/compression_member/compression_welded.py
@@ -2371,7 +2371,7 @@ class Compression_welded(Member):
                 self.web_weld = 0.0
 
             remaining = self.weld.effective - self.web_weld
-            equal_flange = round_up(remaining / 2, 1, 50)
+            equal_flange = round_up(remaining / 2, 1, 10)
 
             self.flange_weld_heel = equal_flange
             self.flange_weld_toe = equal_flange
@@ -2387,7 +2387,7 @@ class Compression_welded(Member):
                 self.web_weld = 0.0
 
             remaining = self.weld.effective - self.web_weld
-            equal_flange = round_up(remaining / 4, 1, 50)
+            equal_flange = round_up(remaining / 4, 1, 10)
 
             self.flange_weld_heel = equal_flange
             self.flange_weld_toe = equal_flange
@@ -2413,8 +2413,8 @@ class Compression_welded(Member):
 
             _check_flange_positive(l_heel, l_toe, "B2B/Star Angles — Long Leg")
 
-            self.flange_weld_heel = round_up(l_heel, 1, 50)
-            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld_heel = round_up(l_heel, 1, 10)
+            self.flange_weld_toe = round_up(l_toe, 1, 10)
             self.flange_weld = self.flange_weld_heel
 
             self.weld.length = (self.web_weld
@@ -2439,8 +2439,8 @@ class Compression_welded(Member):
 
             _check_flange_positive(l_heel, l_toe, "B2B/Star Angles — Short Leg")
 
-            self.flange_weld_heel = round_up(l_heel, 1, 50)
-            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld_heel = round_up(l_heel, 1, 10)
+            self.flange_weld_toe = round_up(l_toe, 1, 10)
             self.flange_weld = self.flange_weld_heel
 
             self.weld.length = (self.web_weld
@@ -2464,8 +2464,8 @@ class Compression_welded(Member):
 
             _check_flange_positive(l_heel, l_toe, "Single Angle — Long Leg")
 
-            self.flange_weld_heel = round_up(l_heel, 1, 50)
-            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld_heel = round_up(l_heel, 1, 10)
+            self.flange_weld_toe = round_up(l_toe, 1, 10)
             self.flange_weld = self.flange_weld_heel
 
             self.weld.length = (self.web_weld
@@ -2489,8 +2489,8 @@ class Compression_welded(Member):
 
             _check_flange_positive(l_heel, l_toe, "Single Angle — Short Leg")
 
-            self.flange_weld_heel = round_up(l_heel, 1, 50)
-            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld_heel = round_up(l_heel, 1, 10)
+            self.flange_weld_toe = round_up(l_toe, 1, 10)
             self.flange_weld = self.flange_weld_heel
 
             self.weld.length = (self.web_weld

--- a/src/osdag_core/design_type/compression_member/compression_welded.py
+++ b/src/osdag_core/design_type/compression_member/compression_welded.py
@@ -2347,82 +2347,172 @@ class Compression_welded(Member):
         self.weld.throat = throat_tk
 
     def weld_plate_length(self, design_dictionary, web=None):
-        """
-        Function to calculate weld length, plate length and plate height
-        """
+
+        # Helper: guard against a non-positive flange weld.
+        def _check_flange_positive(l_heel, l_toe, label):
+            if l_toe <= 0 or l_heel <= 0:
+                self.logger.warning(
+                    ": weld_plate_length — %s: one or both flange weld lengths "
+                    "are non-positive (heel=%.1f mm, toe=%.1f mm).  "
+                    "The web weld is consuming more than its share of the total "
+                    "effective length.  Check weld.effective vs web_weld or "
+                    "increase the weld size.  Clamping to minimum 50 mm.",
+                    label, l_heel, l_toe
+                )
+
+        profile = design_dictionary[KEY_SEC_PROFILE]
+        loc = design_dictionary[KEY_LOCATION]
+
+        # BRANCH 1 — Single Channel
         if design_dictionary[KEY_SEC_PROFILE] == "Channels":
-            if web == None:
+            if web is None:
                 self.web_weld = self.section_property.depth - 2 * self.weld.size
             else:
                 self.web_weld = 0.0
-            self.flange_weld = round_up(((self.weld.effective - self.web_weld) / 2), 1, 50)
-            self.weld.length = (self.web_weld + 2 * self.flange_weld)
 
+            remaining = self.weld.effective - self.web_weld
+            equal_flange = round_up(remaining / 2, 1, 50)
+
+            self.flange_weld_heel = equal_flange
+            self.flange_weld_toe = equal_flange
+            self.flange_weld = equal_flange
+
+            self.weld.length = self.web_weld + 2 * self.flange_weld
+
+        # BRANCH 2 — Back-to-Back Channels
         elif design_dictionary[KEY_SEC_PROFILE] == 'Back to Back Channels':
-            if web == None:
+            if web is None:
                 self.web_weld = 2 * (self.section_property.depth - 2 * self.weld.size)
             else:
                 self.web_weld = 0.0
-            self.flange_weld = round_up(((self.weld.effective - self.web_weld) / 4), 1, 50)
-            self.weld.length = (self.web_weld + 4 * self.flange_weld)
 
+            remaining = self.weld.effective - self.web_weld
+            equal_flange = round_up(remaining / 4, 1, 50)
+
+            self.flange_weld_heel = equal_flange
+            self.flange_weld_toe = equal_flange
+            self.flange_weld = equal_flange
+
+            self.weld.length = self.web_weld + 4 * self.flange_weld
+
+        # BRANCH 3 — Back-to-Back Angles or Star Angles, Long Leg connected
         elif design_dictionary[KEY_SEC_PROFILE] in ["Star Angles", Profile_name_2, Profile_name_3] and design_dictionary[
             KEY_LOCATION] == "Long Leg":
-            if web == None:
+            if web is None:
                 self.web_weld = 2 * (self.section_property.max_leg - 2 * self.weld.size)
             else:
                 self.web_weld = 0.0
-            length_weld = self.section_property.angle_weld_length(self.weld.strength, self.web_weld/2, self.res_force/2, 
-                                                                  self.section_property.Cy, self.section_property.max_leg)
-            self.flange_weld = round_up((length_weld), 1, 50)
-            self.weld.length = (self.web_weld + 4 * self.flange_weld)
 
+            l_heel, l_toe = self.section_property.angle_weld_length(
+                self.weld.strength,
+                self.web_weld / 2,
+                self.res_force / 2,
+                self.section_property.Cy,
+                self.section_property.max_leg
+            )
+
+            _check_flange_positive(l_heel, l_toe, "B2B/Star Angles — Long Leg")
+
+            self.flange_weld_heel = round_up(l_heel, 1, 50)
+            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld = self.flange_weld_heel
+
+            self.weld.length = (self.web_weld
+                                + 2 * self.flange_weld_heel
+                                + 2 * self.flange_weld_toe)
+
+        # BRANCH 4 — Back-to-Back Angles or Star Angles, Short Leg connected
         elif design_dictionary[KEY_SEC_PROFILE] in ["Star Angles", Profile_name_2, Profile_name_3] and design_dictionary[
             KEY_LOCATION] == "Short Leg":
-            if web == None:
+            if web is None:
                 self.web_weld = 2 * (self.section_property.min_leg - 2 * self.weld.size)
             else:
                 self.web_weld = 0.0
-            length_weld = self.section_property.angle_weld_length(self.weld.strength, self.web_weld/2, self.res_force/2, 
-                                                                  self.section_property.Cz, self.section_property.min_leg)
-            self.flange_weld = round_up((length_weld), 1, 50)
-            self.weld.length = (self.web_weld + 4 * self.flange_weld)
 
+            l_heel, l_toe = self.section_property.angle_weld_length(
+                self.weld.strength,
+                self.web_weld / 2,
+                self.res_force / 2,
+                self.section_property.Cz,
+                self.section_property.min_leg
+            )
+
+            _check_flange_positive(l_heel, l_toe, "B2B/Star Angles — Short Leg")
+
+            self.flange_weld_heel = round_up(l_heel, 1, 50)
+            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld = self.flange_weld_heel
+
+            self.weld.length = (self.web_weld
+                                + 2 * self.flange_weld_heel
+                                + 2 * self.flange_weld_toe)
+
+        # BRANCH 5 — Single Angle, Long Leg connected
         elif design_dictionary[KEY_SEC_PROFILE] == Profile_name_1 and design_dictionary[KEY_LOCATION] == "Long Leg":
-            if web == None:
-                self.web_weld = (self.section_property.max_leg - 2 * self.weld.size)
+            if web is None:
+                self.web_weld = self.section_property.max_leg - 2 * self.weld.size
             else:
                 self.web_weld = 0.0
-            length_weld = self.section_property.angle_weld_length(self.weld.strength, self.web_weld, self.res_force, 
-                                                                  self.section_property.Cy, self.section_property.max_leg)
-            self.flange_weld = round_up((length_weld), 1, 50)
-            self.weld.length = (self.web_weld + 2 * self.flange_weld)
 
+            l_heel, l_toe = self.section_property.angle_weld_length(
+                self.weld.strength,
+                self.web_weld,
+                self.res_force,
+                self.section_property.Cy,
+                self.section_property.max_leg
+            )
+
+            _check_flange_positive(l_heel, l_toe, "Single Angle — Long Leg")
+
+            self.flange_weld_heel = round_up(l_heel, 1, 50)
+            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld = self.flange_weld_heel
+
+            self.weld.length = (self.web_weld
+                                + self.flange_weld_heel
+                                + self.flange_weld_toe)
+
+        # BRANCH 6 — Single Angle, Short Leg connected (catch-all)
         else:
-            if web == None:
-                self.web_weld = (self.section_property.min_leg - 2 * self.weld.size)
+            if web is None:
+                self.web_weld = self.section_property.min_leg - 2 * self.weld.size
             else:
                 self.web_weld = 0.0
-            length_weld = self.section_property.angle_weld_length(self.weld.strength, self.web_weld, self.res_force, 
-                                                                  self.section_property.Cz, self.section_property.min_leg)
-            self.flange_weld = round_up((length_weld), 1, 50)
-            self.weld.length = (self.web_weld + 2 * self.flange_weld)
 
-        self.plate.length = self.flange_weld + max((4 * self.weld.size), 30)
+            l_heel, l_toe = self.section_property.angle_weld_length(
+                self.weld.strength,
+                self.web_weld,
+                self.res_force,
+                self.section_property.Cz,
+                self.section_property.min_leg
+            )
+
+            _check_flange_positive(l_heel, l_toe, "Single Angle — Short Leg")
+
+            self.flange_weld_heel = round_up(l_heel, 1, 50)
+            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld = self.flange_weld_heel
+
+            self.weld.length = (self.web_weld
+                                + self.flange_weld_heel
+                                + self.flange_weld_toe)
+
+        # Plate length and height
+        end_return = max(4 * self.weld.size, 30)
+        self.plate.length = self.flange_weld + end_return
+
         if design_dictionary[KEY_SEC_PROFILE] == "Star Angles" and design_dictionary[KEY_LOCATION] == "Long Leg":
-            self.plate.height = 2 * self.section_property.max_leg + max((4 * self.weld.size), 30)
+            self.plate.height = 2 * self.section_property.max_leg + end_return
         elif design_dictionary[KEY_SEC_PROFILE] == "Star Angles" and design_dictionary[KEY_LOCATION] == "Short Leg":
-            self.plate.height = 2 * self.section_property.min_leg + max((4 * self.weld.size), 30)
+            self.plate.height = 2 * self.section_property.min_leg + end_return
         elif design_dictionary[KEY_SEC_PROFILE] in [Profile_name_1, Profile_name_2, Profile_name_3] and design_dictionary[KEY_LOCATION] == "Short Leg":
-            self.plate.height = self.section_property.min_leg + max((4 * self.weld.size), 30)
+            self.plate.height = self.section_property.min_leg + end_return
         elif design_dictionary[KEY_SEC_PROFILE] in [Profile_name_1, Profile_name_2, Profile_name_3] and design_dictionary[KEY_LOCATION] == "Long Leg":
-            self.plate.height = self.section_property.max_leg + max((4 * self.weld.size), 30)
+            self.plate.height = self.section_property.max_leg + end_return
         elif design_dictionary[KEY_SEC_PROFILE] in ['Channels', 'Back to Back Channels']:
-            # For Channels, use depth attribute
-            self.plate.height = self.section_property.depth + max((4 * self.weld.size), 30)
+            self.plate.height = self.section_property.depth + end_return
         else:
-            # Default fallback for angles
-            self.plate.height = self.section_property.max_leg + max((4 * self.weld.size), 30)
+            self.plate.height = self.section_property.max_leg + end_return
 
     def get_plate_thickness(self, design_dictionary):
         """

--- a/src/osdag_core/design_type/tension_member/tension_welded.py
+++ b/src/osdag_core/design_type/tension_member/tension_welded.py
@@ -1259,77 +1259,103 @@ class Tension_welded(Member):
         self.weld.effective = L_eff
         self.weld.throat = throat_tk
 
-    def weld_plate_length (self,design_dictionary, web = None):
+    def weld_plate_length(self, design_dictionary, web=None):
 
         "Function to calculate weld length, plate length and plate height"
 
         if design_dictionary[KEY_SEC_PROFILE] == "Channels":
-            if web == None:
+            if web is None:
                 self.web_weld = self.section_size_1.depth - 2 * self.weld.size
             else:
                 self.web_weld = 0.0
-            self.flange_weld = round_up(((self.weld.effective - self.web_weld ) / 2), 1, 50)
+            self.flange_weld_heel = None  # symmetric — not applicable
+            self.flange_weld_toe = None
+            self.flange_weld = round_up(((self.weld.effective - self.web_weld) / 2), 1, 50)
             self.weld.length = (self.web_weld + 2 * self.flange_weld)
 
         elif design_dictionary[KEY_SEC_PROFILE] == 'Back to Back Channels':
-            if web == None:
+            if web is None:
                 self.web_weld = 2 * (self.section_size_1.depth - 2 * self.weld.size)
             else:
                 self.web_weld = 0.0
-            self.flange_weld = round_up(((self.weld.effective - self.web_weld ) / 4), 1, 50)
+            self.flange_weld_heel = None  # symmetric — not applicable
+            self.flange_weld_toe = None
+            self.flange_weld = round_up(((self.weld.effective - self.web_weld) / 4), 1, 50)
             self.weld.length = (self.web_weld + 4 * self.flange_weld)
 
         elif design_dictionary[KEY_SEC_PROFILE] in ["Star Angles", "Back to Back Angles"] and design_dictionary[
             KEY_LOCATION] == "Long Leg":
-
-            if web == None:
+            if web is None:
                 self.web_weld = 2 * (self.section_size_1.max_leg - 2 * self.weld.size)
             else:
                 self.web_weld = 0.0
-            length_weld = self.section_size_1.angle_weld_length(self.weld.strength,self.web_weld/2,self.res_force/2,self.section_size_1.Cy,self.section_size_1.max_leg )
-            self.flange_weld = round_up((length_weld), 1, 50)
-            self.weld.length = (self.web_weld + 4 * self.flange_weld)
+            l1, l3 = self.section_size_1.angle_weld_length(
+                self.weld.strength, self.web_weld / 2, self.res_force / 2,
+                self.section_size_1.Cy, self.section_size_1.max_leg
+            )
+            self.flange_weld_heel = round_up(l1, 1, 50)  # near centroid
+            self.flange_weld_toe = round_up(l3, 1, 50)  # away from centroid
+            self.flange_weld = self.flange_weld_toe  # governs plate length
+            self.weld.length = self.web_weld + 2 * self.flange_weld_heel + 2 * self.flange_weld_toe
 
         elif design_dictionary[KEY_SEC_PROFILE] in ["Star Angles", "Back to Back Angles"] and design_dictionary[
             KEY_LOCATION] == "Short Leg":
-            if web == None:
+            if web is None:
                 self.web_weld = 2 * (self.section_size_1.min_leg - 2 * self.weld.size)
             else:
                 self.web_weld = 0.0
-            length_weld = self.section_size_1.angle_weld_length(self.weld.strength,self.web_weld/2,self.res_force/2,self.section_size_1.Cz,self.section_size_1.min_leg )
-            self.flange_weld = round_up((length_weld), 1, 50)
-            self.weld.length = (self.web_weld + 4 * self.flange_weld)
+            l1, l3 = self.section_size_1.angle_weld_length(
+                self.weld.strength, self.web_weld / 2, self.res_force / 2,
+                self.section_size_1.Cz, self.section_size_1.min_leg
+            )
+            self.flange_weld_heel = round_up(l1, 1, 50)
+            self.flange_weld_toe = round_up(l3, 1, 50)
+            self.flange_weld = self.flange_weld_toe
+            self.weld.length = self.web_weld + 2 * self.flange_weld_heel + 2 * self.flange_weld_toe
 
         elif design_dictionary[KEY_SEC_PROFILE] == "Angles" and design_dictionary[KEY_LOCATION] == "Long Leg":
-            if web == None:
+            if web is None:
                 self.web_weld = (self.section_size_1.max_leg - 2 * self.weld.size)
             else:
                 self.web_weld = 0.0
-            length_weld = self.section_size_1.angle_weld_length(self.weld.strength,self.web_weld,self.res_force,self.section_size_1.Cy,self.section_size_1.max_leg )
-            self.flange_weld = round_up((length_weld), 1, 50)
-            self.weld.length = (self.web_weld + 2 * self.flange_weld)
+            l1, l3 = self.section_size_1.angle_weld_length(
+                self.weld.strength, self.web_weld, self.res_force,
+                self.section_size_1.Cy, self.section_size_1.max_leg
+            )
+            self.flange_weld_heel = round_up(l1, 1, 50)
+            self.flange_weld_toe = round_up(l3, 1, 50)
+            self.flange_weld = self.flange_weld_toe
+            self.weld.length = self.web_weld + self.flange_weld_heel + self.flange_weld_toe
 
-        else:
-            if web == None:
+        else:  # Angles — Short Leg
+            if web is None:
                 self.web_weld = (self.section_size_1.min_leg - 2 * self.weld.size)
             else:
                 self.web_weld = 0.0
-            length_weld = self.section_size_1.angle_weld_length(self.weld.strength,self.web_weld,self.res_force,self.section_size_1.Cz,self.section_size_1.min_leg )
-            self.flange_weld = round_up((length_weld), 1, 50)
-            self.weld.length = (self.web_weld + 2 * self.flange_weld)
+            l1, l3 = self.section_size_1.angle_weld_length(
+                self.weld.strength, self.web_weld, self.res_force,
+                self.section_size_1.Cz, self.section_size_1.min_leg
+            )
+            self.flange_weld_heel = round_up(l1, 1, 50)
+            self.flange_weld_toe = round_up(l3, 1, 50)
+            self.flange_weld = self.flange_weld_toe
+            self.weld.length = self.web_weld + self.flange_weld_heel + self.flange_weld_toe
 
+        # --- Plate dimensions (governed by the longer toe weld) ---
+        self.plate.length = self.flange_weld + max((4 * self.weld.size), 30)
 
-        self.plate.length = self.flange_weld + max((4 * self.weld.size),30)
         if design_dictionary[KEY_SEC_PROFILE] == "Star Angles" and design_dictionary[KEY_LOCATION] == "Long Leg":
-            self.plate.height = 2 * self.section_size_1.max_leg + max((4 * self.weld.size),30)
+            self.plate.height = 2 * self.section_size_1.max_leg + max((4 * self.weld.size), 30)
         elif design_dictionary[KEY_SEC_PROFILE] == "Star Angles" and design_dictionary[KEY_LOCATION] == "Short Leg":
-            self.plate.height = 2 * self.section_size_1.min_leg + max((4 * self.weld.size),30)
-        elif design_dictionary[KEY_SEC_PROFILE] in ["Back to Back Angles", "Angles"] and design_dictionary[KEY_LOCATION] == "Short Leg":
-            self.plate.height = self.section_size_1.min_leg + max((4 * self.weld.size),30)
-        elif design_dictionary[KEY_SEC_PROFILE] in ["Back to Back Angles","Angles"] and design_dictionary[KEY_LOCATION] == "Long Leg":
-            self.plate.height = self.section_size_1.max_leg + max((4 * self.weld.size),30)
+            self.plate.height = 2 * self.section_size_1.min_leg + max((4 * self.weld.size), 30)
+        elif design_dictionary[KEY_SEC_PROFILE] in ["Back to Back Angles", "Angles"] and design_dictionary[
+            KEY_LOCATION] == "Short Leg":
+            self.plate.height = self.section_size_1.min_leg + max((4 * self.weld.size), 30)
+        elif design_dictionary[KEY_SEC_PROFILE] in ["Back to Back Angles", "Angles"] and design_dictionary[
+            KEY_LOCATION] == "Long Leg":
+            self.plate.height = self.section_size_1.max_leg + max((4 * self.weld.size), 30)
         else:
-            self.plate.height = self.section_size_1.depth + max((4 * self.weld.size),30)
+            self.plate.height = self.section_size_1.depth + max((4 * self.weld.size), 30)
 
     def member_check(self,design_dictionary):
 

--- a/src/osdag_core/design_type/tension_member/tension_welded.py
+++ b/src/osdag_core/design_type/tension_member/tension_welded.py
@@ -1261,101 +1261,176 @@ class Tension_welded(Member):
 
     def weld_plate_length(self, design_dictionary, web=None):
 
-        "Function to calculate weld length, plate length and plate height"
+        # Helper: guard against a non-positive flange weld.
+        def _check_flange_positive(l_heel, l_toe, label):
+            if l_toe <= 0 or l_heel <= 0:
+                self.logger.warning(
+                    ": weld_plate_length — %s: one or both flange weld lengths "
+                    "are non-positive (heel=%.1f mm, toe=%.1f mm).  "
+                    "The web weld is consuming more than its share of the total "
+                    "effective length.  Check weld.effective vs web_weld or "
+                    "increase the weld size.  Clamping to minimum 50 mm.",
+                    label, l_heel, l_toe
+                )
 
+        # BRANCH 1 — Single Channel
         if design_dictionary[KEY_SEC_PROFILE] == "Channels":
+
             if web is None:
                 self.web_weld = self.section_size_1.depth - 2 * self.weld.size
             else:
                 self.web_weld = 0.0
-            self.flange_weld_heel = None  # symmetric — not applicable
-            self.flange_weld_toe = None
-            self.flange_weld = round_up(((self.weld.effective - self.web_weld) / 2), 1, 50)
-            self.weld.length = (self.web_weld + 2 * self.flange_weld)
 
+            remaining = self.weld.effective - self.web_weld
+            equal_flange = round_up(remaining / 2, 1, 50)
+
+            self.flange_weld_heel = equal_flange
+            self.flange_weld_toe = equal_flange
+            self.flange_weld = equal_flange
+
+            self.weld.length = self.web_weld + 2 * self.flange_weld
+
+        # BRANCH 2 — Back-to-Back Channels
         elif design_dictionary[KEY_SEC_PROFILE] == 'Back to Back Channels':
+
             if web is None:
                 self.web_weld = 2 * (self.section_size_1.depth - 2 * self.weld.size)
             else:
                 self.web_weld = 0.0
-            self.flange_weld_heel = None  # symmetric — not applicable
-            self.flange_weld_toe = None
-            self.flange_weld = round_up(((self.weld.effective - self.web_weld) / 4), 1, 50)
-            self.weld.length = (self.web_weld + 4 * self.flange_weld)
 
-        elif design_dictionary[KEY_SEC_PROFILE] in ["Star Angles", "Back to Back Angles"] and design_dictionary[
-            KEY_LOCATION] == "Long Leg":
+            remaining = self.weld.effective - self.web_weld
+            equal_flange = round_up(remaining / 4, 1, 50)
+
+            self.flange_weld_heel = equal_flange
+            self.flange_weld_toe = equal_flange
+            self.flange_weld = equal_flange
+
+            self.weld.length = self.web_weld + 4 * self.flange_weld
+
+        # BRANCH 3 — Back-to-Back Angles or Star Angles, Long Leg connected
+        elif (design_dictionary[KEY_SEC_PROFILE] in ["Star Angles", "Back to Back Angles"]
+              and design_dictionary[KEY_LOCATION] == "Long Leg"):
+
             if web is None:
                 self.web_weld = 2 * (self.section_size_1.max_leg - 2 * self.weld.size)
             else:
                 self.web_weld = 0.0
-            l1, l3 = self.section_size_1.angle_weld_length(
-                self.weld.strength, self.web_weld / 2, self.res_force / 2,
-                self.section_size_1.Cy, self.section_size_1.max_leg
-            )
-            self.flange_weld_heel = round_up(l1, 1, 50)  # near centroid
-            self.flange_weld_toe = round_up(l3, 1, 50)  # away from centroid
-            self.flange_weld = self.flange_weld_toe  # governs plate length
-            self.weld.length = self.web_weld + 2 * self.flange_weld_heel + 2 * self.flange_weld_toe
 
-        elif design_dictionary[KEY_SEC_PROFILE] in ["Star Angles", "Back to Back Angles"] and design_dictionary[
-            KEY_LOCATION] == "Short Leg":
+            l_heel, l_toe = self.section_size_1.angle_weld_length(
+                weld_strength=self.weld.strength,
+                depth_weld=self.web_weld / 2,
+                force=self.res_force / 2,
+                C=self.section_size_1.Cy,
+                depth=self.section_size_1.max_leg
+            )
+
+            _check_flange_positive(l_heel, l_toe, "B2B/Star Angles — Long Leg")
+
+            self.flange_weld_heel = round_up(l_heel, 1, 50)
+            self.flange_weld_toe = round_up(l_toe, 1, 50)
+
+            self.flange_weld = self.flange_weld_heel
+
+            self.weld.length = (self.web_weld + 2 * self.flange_weld_heel + 2 * self.flange_weld_toe)
+
+        # BRANCH 4 — Back-to-Back Angles or Star Angles, Short Leg connected
+        elif (design_dictionary[KEY_SEC_PROFILE] in ["Star Angles", "Back to Back Angles"]
+              and design_dictionary[KEY_LOCATION] == "Short Leg"):
+
             if web is None:
                 self.web_weld = 2 * (self.section_size_1.min_leg - 2 * self.weld.size)
             else:
                 self.web_weld = 0.0
-            l1, l3 = self.section_size_1.angle_weld_length(
-                self.weld.strength, self.web_weld / 2, self.res_force / 2,
-                self.section_size_1.Cz, self.section_size_1.min_leg
-            )
-            self.flange_weld_heel = round_up(l1, 1, 50)
-            self.flange_weld_toe = round_up(l3, 1, 50)
-            self.flange_weld = self.flange_weld_toe
-            self.weld.length = self.web_weld + 2 * self.flange_weld_heel + 2 * self.flange_weld_toe
 
-        elif design_dictionary[KEY_SEC_PROFILE] == "Angles" and design_dictionary[KEY_LOCATION] == "Long Leg":
+            l_heel, l_toe = self.section_size_1.angle_weld_length(
+                weld_strength=self.weld.strength,
+                depth_weld=self.web_weld / 2,
+                force=self.res_force / 2,
+                C=self.section_size_1.Cz,
+                depth=self.section_size_1.min_leg
+            )
+
+            _check_flange_positive(l_heel, l_toe, "B2B/Star Angles — Short Leg")
+
+            self.flange_weld_heel = round_up(l_heel, 1, 50)
+            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld = self.flange_weld_heel
+
+            self.weld.length = (self.web_weld + 2 * self.flange_weld_heel + 2 * self.flange_weld_toe)
+
+        # BRANCH 5 — Single Angle, Long Leg connected
+        elif (design_dictionary[KEY_SEC_PROFILE] == "Angles"
+              and design_dictionary[KEY_LOCATION] == "Long Leg"):
+
             if web is None:
-                self.web_weld = (self.section_size_1.max_leg - 2 * self.weld.size)
+                self.web_weld = self.section_size_1.max_leg - 2 * self.weld.size
             else:
                 self.web_weld = 0.0
-            l1, l3 = self.section_size_1.angle_weld_length(
-                self.weld.strength, self.web_weld, self.res_force,
-                self.section_size_1.Cy, self.section_size_1.max_leg
+
+            l_heel, l_toe = self.section_size_1.angle_weld_length(
+                weld_strength=self.weld.strength,
+                depth_weld=self.web_weld,
+                force=self.res_force,
+                C=self.section_size_1.Cy,
+                depth=self.section_size_1.max_leg
             )
-            self.flange_weld_heel = round_up(l1, 1, 50)
-            self.flange_weld_toe = round_up(l3, 1, 50)
-            self.flange_weld = self.flange_weld_toe
-            self.weld.length = self.web_weld + self.flange_weld_heel + self.flange_weld_toe
 
-        else:  # Angles — Short Leg
-            if web is None:
-                self.web_weld = (self.section_size_1.min_leg - 2 * self.weld.size)
-            else:
-                self.web_weld = 0.0
-            l1, l3 = self.section_size_1.angle_weld_length(
-                self.weld.strength, self.web_weld, self.res_force,
-                self.section_size_1.Cz, self.section_size_1.min_leg
-            )
-            self.flange_weld_heel = round_up(l1, 1, 50)
-            self.flange_weld_toe = round_up(l3, 1, 50)
-            self.flange_weld = self.flange_weld_toe
-            self.weld.length = self.web_weld + self.flange_weld_heel + self.flange_weld_toe
+            _check_flange_positive(l_heel, l_toe, "Single Angle — Long Leg")
 
-        # --- Plate dimensions (governed by the longer toe weld) ---
-        self.plate.length = self.flange_weld + max((4 * self.weld.size), 30)
+            self.flange_weld_heel = round_up(l_heel, 1, 50)
+            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld = self.flange_weld_heel
 
-        if design_dictionary[KEY_SEC_PROFILE] == "Star Angles" and design_dictionary[KEY_LOCATION] == "Long Leg":
-            self.plate.height = 2 * self.section_size_1.max_leg + max((4 * self.weld.size), 30)
-        elif design_dictionary[KEY_SEC_PROFILE] == "Star Angles" and design_dictionary[KEY_LOCATION] == "Short Leg":
-            self.plate.height = 2 * self.section_size_1.min_leg + max((4 * self.weld.size), 30)
-        elif design_dictionary[KEY_SEC_PROFILE] in ["Back to Back Angles", "Angles"] and design_dictionary[
-            KEY_LOCATION] == "Short Leg":
-            self.plate.height = self.section_size_1.min_leg + max((4 * self.weld.size), 30)
-        elif design_dictionary[KEY_SEC_PROFILE] in ["Back to Back Angles", "Angles"] and design_dictionary[
-            KEY_LOCATION] == "Long Leg":
-            self.plate.height = self.section_size_1.max_leg + max((4 * self.weld.size), 30)
+            self.weld.length = (self.web_weld + self.flange_weld_heel + self.flange_weld_toe)
+
+        # BRANCH 6 — Single Angle, Short Leg connected (catch-all)
         else:
-            self.plate.height = self.section_size_1.depth + max((4 * self.weld.size), 30)
+
+            if web is None:
+                self.web_weld = self.section_size_1.min_leg - 2 * self.weld.size
+            else:
+                self.web_weld = 0.0
+
+            l_heel, l_toe = self.section_size_1.angle_weld_length(
+                weld_strength=self.weld.strength,
+                depth_weld=self.web_weld,
+                force=self.res_force,
+                C=self.section_size_1.Cz,
+                depth=self.section_size_1.min_leg
+            )
+
+            _check_flange_positive(l_heel, l_toe, "Single Angle — Short Leg")
+
+            self.flange_weld_heel = round_up(l_heel, 1, 50)
+            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld = self.flange_weld_heel
+
+            self.weld.length = (self.web_weld
+                                + self.flange_weld_heel
+                                + self.flange_weld_toe)
+
+        # Plate length
+        end_return = max(4 * self.weld.size, 30)
+        self.plate.length = self.flange_weld + end_return
+
+        # Plate height
+        profile = design_dictionary[KEY_SEC_PROFILE]
+        loc = design_dictionary[KEY_LOCATION]
+
+        if profile == "Star Angles" and loc == "Long Leg":
+            self.plate.height = 2 * self.section_size_1.max_leg + end_return
+
+        elif profile == "Star Angles" and loc == "Short Leg":
+            self.plate.height = 2 * self.section_size_1.min_leg + end_return
+
+        elif profile in ["Back to Back Angles", "Angles"] and loc == "Short Leg":
+            self.plate.height = self.section_size_1.min_leg + end_return
+
+        elif profile in ["Back to Back Angles", "Angles"] and loc == "Long Leg":
+            self.plate.height = self.section_size_1.max_leg + end_return
+
+        else:
+            self.plate.height = self.section_size_1.depth + end_return
 
     def member_check(self,design_dictionary):
 

--- a/src/osdag_core/design_type/tension_member/tension_welded.py
+++ b/src/osdag_core/design_type/tension_member/tension_welded.py
@@ -1282,7 +1282,7 @@ class Tension_welded(Member):
                 self.web_weld = 0.0
 
             remaining = self.weld.effective - self.web_weld
-            equal_flange = round_up(remaining / 2, 1, 50)
+            equal_flange = round_up(remaining / 2, 1, 10)
 
             self.flange_weld_heel = equal_flange
             self.flange_weld_toe = equal_flange
@@ -1299,7 +1299,7 @@ class Tension_welded(Member):
                 self.web_weld = 0.0
 
             remaining = self.weld.effective - self.web_weld
-            equal_flange = round_up(remaining / 4, 1, 50)
+            equal_flange = round_up(remaining / 4, 1, 10)
 
             self.flange_weld_heel = equal_flange
             self.flange_weld_toe = equal_flange
@@ -1326,8 +1326,8 @@ class Tension_welded(Member):
 
             _check_flange_positive(l_heel, l_toe, "B2B/Star Angles — Long Leg")
 
-            self.flange_weld_heel = round_up(l_heel, 1, 50)
-            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld_heel = round_up(l_heel, 1, 10)
+            self.flange_weld_toe = round_up(l_toe, 1, 10)
 
             self.flange_weld = self.flange_weld_heel
 
@@ -1352,8 +1352,8 @@ class Tension_welded(Member):
 
             _check_flange_positive(l_heel, l_toe, "B2B/Star Angles — Short Leg")
 
-            self.flange_weld_heel = round_up(l_heel, 1, 50)
-            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld_heel = round_up(l_heel, 1, 10)
+            self.flange_weld_toe = round_up(l_toe, 1, 10)
             self.flange_weld = self.flange_weld_heel
 
             self.weld.length = (self.web_weld + 2 * self.flange_weld_heel + 2 * self.flange_weld_toe)
@@ -1377,8 +1377,8 @@ class Tension_welded(Member):
 
             _check_flange_positive(l_heel, l_toe, "Single Angle — Long Leg")
 
-            self.flange_weld_heel = round_up(l_heel, 1, 50)
-            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld_heel = round_up(l_heel, 1, 10)
+            self.flange_weld_toe = round_up(l_toe, 1, 10)
             self.flange_weld = self.flange_weld_heel
 
             self.weld.length = (self.web_weld + self.flange_weld_heel + self.flange_weld_toe)
@@ -1401,8 +1401,8 @@ class Tension_welded(Member):
 
             _check_flange_positive(l_heel, l_toe, "Single Angle — Short Leg")
 
-            self.flange_weld_heel = round_up(l_heel, 1, 50)
-            self.flange_weld_toe = round_up(l_toe, 1, 50)
+            self.flange_weld_heel = round_up(l_heel, 1, 10)
+            self.flange_weld_toe = round_up(l_toe, 1, 10)
             self.flange_weld = self.flange_weld_heel
 
             self.weld.length = (self.web_weld

--- a/src/osdag_core/utils/common/component.py
+++ b/src/osdag_core/utils/common/component.py
@@ -1941,14 +1941,16 @@ class Angle(Material):
         conn.close()
 
     def angle_weld_length(self, weld_strength, depth_weld, force, C, depth):
-
         "Function to calculate weld length for angles based on the force transfer pattern"
 
-        f2 = weld_strength * depth_weld
-        f3 = force * (1 - C / depth) - f2 / 2
-        l3 = f3 / weld_strength
+        f2 = weld_strength * depth_weld  # web weld
+        f3 = force * (1 - C / depth) - f2 / 2  # upper flange weld
+        f1 = force * (C / depth) - f2 / 2  # lower flange weld
 
-        return l3
+        l3 = f3 / weld_strength  # upper flange weld length
+        l1 = f1 / weld_strength  # lower flange weld length
+
+        return l1, l3
 
     def get_available_seated_list(self, input_angle_list, max_leg_length=math.inf, min_leg_length=0.0, position="outer",
                                   t_min=0.0):

--- a/src/osdag_core/utils/common/component.py
+++ b/src/osdag_core/utils/common/component.py
@@ -1941,16 +1941,20 @@ class Angle(Material):
         conn.close()
 
     def angle_weld_length(self, weld_strength, depth_weld, force, C, depth):
-        "Function to calculate weld length for angles based on the force transfer pattern"
+        # Force carried by the web (outstanding-leg) weld
+        f_web = weld_strength * depth_weld
 
-        f2 = weld_strength * depth_weld  # web weld
-        f3 = force * (1 - C / depth) - f2 / 2  # upper flange weld
-        f1 = force * (C / depth) - f2 / 2  # lower flange weld
+        # Force share on the heel side — farther from base edge, closer to Cy
+        f_heel = force * (1 - C / depth) - f_web / 2
 
-        l3 = f3 / weld_strength  # upper flange weld length
-        l1 = f1 / weld_strength  # lower flange weld length
+        # Force share on the toe side — closer to base edge, farther from Cy
+        f_toe = force * (C / depth) - f_web / 2
 
-        return l1, l3
+        # Convert force shares to required weld lengths
+        l_heel = f_heel / weld_strength
+        l_toe = f_toe / weld_strength
+
+        return l_heel, l_toe
 
     def get_available_seated_list(self, input_angle_list, max_leg_length=math.inf, min_leg_length=0.0, position="outer",
                                   t_min=0.0):


### PR DESCRIPTION
This PR updates the weld distribution logic for both tension members (welded to end gusset) and compression members (welded to end gusset) to better align with centroid-based behavior.

Changes made:
- Updated ```angle_weld_length()``` to account for flange weld distribution based on centroid values
- Modified ```createTensionCAD()``` and ```createStrutWeldedCAD()``` to support heel and toe flange welds
- Updated ```welded_plate_length()``` in respective design type files for proper weld instantiation
- Revised ```createWeldGeometry()``` functions in respective CAD files to reflect the updated weld distribution