### PR TITLE
Block shear fixes across three connection modules

### DIFF
--- a/src/osdag/design_type/connection/cleat_angle_connection.py
+++ b/src/osdag/design_type/connection/cleat_angle_connection.py
@@ -338,6 +338,64 @@ class CleatAngleConnection(ShearConnection):
                 chkbox.setChecked(Qt.Unchecked)
         ui.commLogicObj.display_3DModel("cleatAngle", bgcolor)
 
+    def sptd_leg_capacities(self, flag):
+        """Capacity details for supported leg (connected to beam web)."""
+        capacities = []
+
+        t99 = (None, 'Failure Pattern due to Shear (Supported Leg)', TYPE_SECTION, None)
+        capacities.append(t99)
+
+        capacities.append((KEY_OUT_PLATE_SHEAR, KEY_OUT_DISP_PLATE_SHEAR, TYPE_TEXTBOX,
+            round(self.sptd_leg.cleat_shear_capacity / 1000, 2) if flag else ''))
+        capacities.append((KEY_OUT_PLATE_RUPTURE, KEY_OUT_DISP_PLATE_RUPTURE, TYPE_TEXTBOX,
+            round(self.sptd_leg.shear_rupture_capacity / 1000, 2) if flag else ''))
+        capacities.append((KEY_OUT_PLATE_BLK_SHEAR, KEY_OUT_DISP_PLATE_BLK_SHEAR, TYPE_TEXTBOX,
+            round(self.sptd_leg.block_shear_capacity_shear / 1000, 2) if flag else ''))
+
+        t99 = (None, 'Failure Pattern due to Tension (Supported Leg)', TYPE_SECTION, None)
+        capacities.append(t99)
+
+        capacities.append((KEY_OUT_PLATE_TENSION, KEY_OUT_DISP_PLATE_TENSION, TYPE_TEXTBOX,
+            round(self.sptd_leg.tension_yielding_capacity / 1000, 2) if flag else ''))
+        capacities.append((KEY_OUT_PLATE_TENSION_RUP, KEY_OUT_DISP_PLATE_TENSION_RUP, TYPE_TEXTBOX,
+            round(self.sptd_leg.tension_rupture_capacity / 1000, 2) if flag else ''))
+        capacities.append((KEY_OUT_PLATE_BLK_SHEAR_AXIAL, KEY_OUT_DISP_PLATE_BLK_SHEAR_AXIAL, TYPE_TEXTBOX,
+            round(self.sptd_leg.block_shear_capacity_axial / 1000, 2) if flag else ''))
+
+        t99 = (None, 'Section (Beam Web) Block Shear', TYPE_SECTION, None)
+        capacities.append(t99)
+
+        capacities.append(('Section.BlockShearAxial', 'Section Block Shear Capacity (kN)', TYPE_TEXTBOX,
+            round(self.supported_section.block_shear_capacity_axial / 1000, 2) if flag else ''))
+
+        return capacities
+
+    def spting_leg_capacities(self, flag):
+        """Capacity details for supporting leg (connected to column/supporting member)."""
+        capacities = []
+
+        t99 = (None, 'Failure Pattern due to Shear (Supporting Leg)', TYPE_SECTION, None)
+        capacities.append(t99)
+
+        capacities.append((KEY_OUT_PLATE_SHEAR, KEY_OUT_DISP_PLATE_SHEAR, TYPE_TEXTBOX,
+            round(self.spting_leg.cleat_shear_capacity / 1000, 2) if flag else ''))
+        capacities.append((KEY_OUT_PLATE_RUPTURE, KEY_OUT_DISP_PLATE_RUPTURE, TYPE_TEXTBOX,
+            round(self.spting_leg.shear_rupture_capacity / 1000, 2) if flag else ''))
+        capacities.append((KEY_OUT_PLATE_BLK_SHEAR, KEY_OUT_DISP_PLATE_BLK_SHEAR, TYPE_TEXTBOX,
+            round(self.spting_leg.block_shear_capacity_shear / 1000, 2) if flag else ''))
+
+        t99 = (None, 'Failure Pattern due to Tension (Supporting Leg)', TYPE_SECTION, None)
+        capacities.append(t99)
+
+        capacities.append((KEY_OUT_PLATE_TENSION, KEY_OUT_DISP_PLATE_TENSION, TYPE_TEXTBOX,
+            round(self.spting_leg.tension_yielding_capacity / 1000, 2) if flag else ''))
+        capacities.append((KEY_OUT_PLATE_TENSION_RUP, KEY_OUT_DISP_PLATE_TENSION_RUP, TYPE_TEXTBOX,
+            round(self.spting_leg.tension_rupture_capacity / 1000, 2) if flag else ''))
+        capacities.append((KEY_OUT_PLATE_BLK_SHEAR_AXIAL, KEY_OUT_DISP_PLATE_BLK_SHEAR_AXIAL, TYPE_TEXTBOX,
+            round(self.spting_leg.block_shear_capacity_axial / 1000, 2) if flag else ''))
+
+        return capacities
+
     def output_values(self, flag):
         """
         Function to return a list of tuples to be displayed as the UI.(Output Dock)
@@ -363,6 +421,10 @@ class CleatAngleConnection(ShearConnection):
 
         t18 = (KEY_OUT_CLEAT_BLK_SHEAR, KEY_DISP_BLK_SHEAR, TYPE_TEXTBOX, round(self.sptd_leg.block_shear_capacity / 1000, 2) if flag else '', True)
         out_list.append(t18)
+
+        t_cap_sptd = ('button_sptd_cap', KEY_OUT_DISP_PLATE_CAPACITIES, TYPE_OUT_BUTTON,
+                       ['Capacity Details', self.sptd_leg_capacities], True)
+        out_list.append(t_cap_sptd)
 
         t19 = (KEY_OUT_CLEAT_MOM_DEMAND, KEY_DISP_MOM_DEMAND, TYPE_TEXTBOX, round(self.sptd_leg.moment_demand / 1000000, 2) if flag else '', True)
         out_list.append(t19)
@@ -431,6 +493,10 @@ class CleatAngleConnection(ShearConnection):
 
         t19 = (KEY_OUT_SPTING_SPACING, KEY_OUT_DISP_SPACING, TYPE_OUT_BUTTON, ['Spacing Details', self.spting_spacing], True)
         out_list.append(t19)
+
+        t_cap_spting = ('button_spting_cap', KEY_OUT_DISP_PLATE_CAPACITIES, TYPE_OUT_BUTTON,
+                         ['Capacity Details', self.spting_leg_capacities], True)
+        out_list.append(t_cap_spting)
 
         """      Bolt Properties- Supporting leg: End        """
         """"""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -901,6 +967,7 @@ class CleatAngleConnection(ShearConnection):
             logger.error("The connection cannot be designed with provided bolt diameters or cleat angle list")
         else:
             self.select_optimum(self)
+            self.compute_all_block_shear_capacities(self)
             # print("why repeat",self.bolt.bolt_diameter_provided,self.cleat.designation)
             self.for_3D_view(self)
             self.design_status = True
@@ -908,6 +975,101 @@ class CleatAngleConnection(ShearConnection):
             self.spting_leg.design_status = True
             self.sptd_leg.grip_status = True
             self.spting_leg.grip_status = True
+
+    def compute_all_block_shear_capacities(self):
+        """Compute full set of yielding, rupture, and block shear capacities for both legs.
+        IS 800:2007, Cl. 6.4.1 for block shear, Cl. 8.4 for shear yielding, Cl. 6.2/6.3.1 for tension."""
+        bolt_hole_dia = self.bolt.dia_hole
+        bolt_hole_dia2 = self.bolt2.dia_hole
+
+        # === SUPPORTED LEG (2 * cleat thickness, bolted to beam web) ===
+        n_row = self.sptd_leg.bolts_one_line
+        n_col = self.sptd_leg.bolt_line
+        pitch = self.sptd_leg.gauge_provided    # along height (vertical bolt spacing)
+        gauge = self.sptd_leg.pitch_provided    # perpendicular (horizontal bolt spacing)
+        end = self.sptd_leg.edge_dist_provided  # vertical edge distance
+        edge = self.sptd_leg.end_dist_provided  # horizontal end distance
+        t = 2 * self.cleat.thickness            # double angle
+        fy = self.sptd_leg.fy
+        fu = self.sptd_leg.fu
+        h = self.sptd_leg.height
+
+        # Shear yielding (already computed as cleat_shear_capacity)
+        # Shear rupture
+        A_vn = (h - float(n_row) * bolt_hole_dia) * t
+        self.sptd_leg.shear_rupture_capacity = AISC.cl_j_4_2_b_shear_rupture(A_vn, fu)
+
+        # Block shear for shear pattern (L-shape) - copy existing value
+        self.sptd_leg.block_shear_capacity_shear = self.sptd_leg.block_shear_capacity
+
+        # Tension yielding
+        A_g = h * t
+        self.sptd_leg.tension_yielding_capacity = IS800_2007.cl_6_2_tension_yielding_strength(A_g, fy)
+
+        # Tension rupture
+        A_n = (h - n_col * bolt_hole_dia) * t
+        self.sptd_leg.tension_rupture_capacity = IS800_2007.cl_6_3_1_tension_rupture_strength(A_n, fu)
+
+        # Block shear for tension pattern (U-shape)
+        t_A_tg = ((n_row - 1) * pitch) * t
+        t_A_tn = ((n_row - 1) * pitch - (float(n_row) - 1.0) * bolt_hole_dia) * t
+        t_A_vg = 2 * edge * t
+        t_A_vn = 2 * (edge - 0.5 * bolt_hole_dia) * t
+        self.sptd_leg.block_shear_capacity_axial = IS800_2007.cl_6_4_1_block_shear_strength(
+            t_A_vg, t_A_vn, t_A_tg, t_A_tn, fu, fy)
+
+        # === SUPPORTING LEG (1 * cleat thickness, bolted to column/supporting member) ===
+        n_row_s = self.spting_leg.bolts_one_line
+        n_col_s = self.spting_leg.bolt_line
+        pitch_s = self.spting_leg.gauge_provided
+        gauge_s = self.spting_leg.pitch_provided
+        end_s = self.spting_leg.edge_dist_provided
+        edge_s = self.spting_leg.end_dist_provided
+        t_s = self.cleat.thickness
+        fy_s = self.spting_leg.fy
+        fu_s = self.spting_leg.fu
+        h_s = self.spting_leg.height
+
+        # Shear yielding
+        self.spting_leg.cleat_shear_capacity = IS800_2007.cl_8_4_design_shear_strength(h_s * t_s, fy_s)
+
+        # Shear rupture
+        A_vn_s = (h_s - float(n_row_s) * bolt_hole_dia2) * t_s
+        self.spting_leg.shear_rupture_capacity = AISC.cl_j_4_2_b_shear_rupture(A_vn_s, fu_s)
+
+        # Block shear for shear (L-shape)
+        s_A_vg = ((n_row_s - 1) * pitch_s + end_s) * t_s
+        s_A_vn = ((n_row_s - 1) * pitch_s + end_s - (float(n_row_s) - 0.5) * bolt_hole_dia2) * t_s
+        s_A_tg = edge_s * t_s
+        s_A_tn = (edge_s - 0.5 * bolt_hole_dia2) * t_s
+        self.spting_leg.block_shear_capacity_shear = IS800_2007.cl_6_4_1_block_shear_strength(
+            s_A_vg, s_A_vn, s_A_tg, s_A_tn, fu_s, fy_s)
+
+        # Tension yielding
+        A_g_s = h_s * t_s
+        self.spting_leg.tension_yielding_capacity = IS800_2007.cl_6_2_tension_yielding_strength(A_g_s, fy_s)
+
+        # Tension rupture
+        A_n_s = (h_s - n_col_s * bolt_hole_dia2) * t_s
+        self.spting_leg.tension_rupture_capacity = IS800_2007.cl_6_3_1_tension_rupture_strength(A_n_s, fu_s)
+
+        # Block shear for tension (U-shape)
+        ts_A_tg = ((n_row_s - 1) * pitch_s) * t_s
+        ts_A_tn = ((n_row_s - 1) * pitch_s - (float(n_row_s) - 1.0) * bolt_hole_dia2) * t_s
+        ts_A_vg = 2 * edge_s * t_s
+        ts_A_vn = 2 * (edge_s - 0.5 * bolt_hole_dia2) * t_s
+        self.spting_leg.block_shear_capacity_axial = IS800_2007.cl_6_4_1_block_shear_strength(
+            ts_A_vg, ts_A_vn, ts_A_tg, ts_A_tn, fu_s, fy_s)
+
+        # === SECTION (beam web) tension block shear for supported leg ===
+        web_thick = self.supported_section.web_thickness
+        w_A_tg = ((n_row - 1) * pitch) * web_thick
+        w_A_tn = ((n_row - 1) * pitch - (float(n_row) - 1.0) * bolt_hole_dia) * web_thick
+        w_A_vg = 2 * edge * web_thick
+        w_A_vn = 2 * (edge - 0.5 * bolt_hole_dia) * web_thick
+        self.supported_section.block_shear_capacity_axial = IS800_2007.cl_6_4_1_block_shear_strength(
+            w_A_vg, w_A_vn, w_A_tg, w_A_tn,
+            self.supported_section.fu, self.supported_section.fy)
 
     def select_optimum(self):
         """This function sorts the list of available options and selects the combination with least leg size or

--- a/src/osdag/design_type/connection/end_plate_connection.py
+++ b/src/osdag/design_type/connection/end_plate_connection.py
@@ -876,6 +876,26 @@ class EndPlateConnection(ShearConnection):
         self.plate.plate_block_shear_capacity = a[0][21]
         self.plate.plate_moment_capacity = a[0][22]
 
+        # Recompute full plate capacities for display (shear/tension yielding, rupture, block shear)
+        self.get_plate_capacity(self, self.plate.thickness_provided, self.plate.height,
+                                self.plate.pitch_provided, self.bolt.min_edge_dist_round,
+                                self.plate.end_dist_provided, self.plate.bolts_one_line, self.bolt.dia_hole)
+
+        # Section tension block shear (IS 800:2007 Cl. 6.4.1)
+        web_thick = self.supported_section.web_thickness
+        n_row_sec = self.plate.bolts_one_line
+        pitch_sec = self.plate.pitch_provided
+        bolt_hole_dia_sec = self.bolt.dia_hole
+        edge_sec = self.bolt.min_edge_dist_round
+
+        sec_A_tg = ((n_row_sec - 1) * pitch_sec) * web_thick
+        sec_A_tn = ((n_row_sec - 1) * pitch_sec - (float(n_row_sec) - 1.0) * bolt_hole_dia_sec) * web_thick
+        sec_A_vg = 2 * edge_sec * web_thick
+        sec_A_vn = 2 * (edge_sec - 0.5 * bolt_hole_dia_sec) * web_thick
+        self.supported_section.block_shear_capacity_axial = IS800_2007.cl_6_4_1_block_shear_strength(
+            sec_A_vg, sec_A_vn, sec_A_tg, sec_A_tn,
+            self.supported_section.fu, self.supported_section.fy)
+
         self.weld.length = a[0][4]
         self.weld.size = a[0][23]
         self.weld.stress = a[0][24]
@@ -1121,6 +1141,11 @@ class EndPlateConnection(ShearConnection):
         A_v = p_h* p_th
         plate_shear_yielding_capacity = IS800_2007.cl_8_4_design_shear_strength(A_v, self.plate.fy)
 
+        # Shear rupture capacity
+        A_vn_rup = (p_h - float(n_row) * bolt_hole_dia) * p_th
+        plate_shear_rupture_capacity = AISC.cl_j_4_2_b_shear_rupture(A_vn_rup, self.plate.fu)
+
+        # Block shear for shear pattern (L-shape)
         A_vg = ((n_row-1) * pitch + end) * p_th
         A_vn = ((n_row-1) * pitch + end - (float(n_row)-0.5) * bolt_hole_dia) * p_th
         A_tg = 2 * self.bolt.min_edge_dist_round * p_th
@@ -1128,6 +1153,27 @@ class EndPlateConnection(ShearConnection):
 
         plate_block_shear_capacity = IS800_2007.cl_6_4_1_block_shear_strength(A_vg, A_vn, A_tg, A_tn, self.plate.fu, self.plate.fy)
         plate_shear_capacity = round((min(plate_shear_yielding_capacity, plate_block_shear_capacity) )/ 1000, 2)
+
+        # Store individual capacities for display
+        self.plate.shear_yielding_capacity = plate_shear_yielding_capacity
+        self.plate.shear_rupture_capacity = plate_shear_rupture_capacity
+        self.plate.block_shear_capacity_shear = plate_block_shear_capacity
+
+        # Tension yielding capacity
+        A_g = p_h * p_th
+        self.plate.tension_yielding_capacity = IS800_2007.cl_6_2_tension_yielding_strength(A_g, self.plate.fy)
+
+        # Tension rupture capacity
+        A_n = (p_h - n_row * bolt_hole_dia) * p_th
+        self.plate.tension_rupture_capacity = IS800_2007.cl_6_3_1_tension_rupture_strength(A_n, self.plate.fu)
+
+        # Block shear for tension pattern (U-shape)
+        t_A_tg = ((n_row - 1) * pitch) * p_th
+        t_A_tn = ((n_row - 1) * pitch - (float(n_row) - 1.0) * bolt_hole_dia) * p_th
+        t_A_vg = 2 * self.bolt.min_edge_dist_round * p_th
+        t_A_vn = 2 * (self.bolt.min_edge_dist_round - 0.5 * bolt_hole_dia) * p_th
+        self.plate.block_shear_capacity_axial = IS800_2007.cl_6_4_1_block_shear_strength(
+            t_A_vg, t_A_vn, t_A_tg, t_A_tn, self.plate.fu, self.plate.fy)
 
         return plate_moment_capacity, plate_shear_capacity, plate_block_shear_capacity
 
@@ -1394,17 +1440,29 @@ class EndPlateConnection(ShearConnection):
 
         capacities = []
 
-        t17 = (KEY_OUT_PLATE_SHEAR, KEY_OUT_DISP_PLATE_SHEAR, TYPE_TEXTBOX, self.output[0][20] if flag else '')
+        t17 = (KEY_OUT_PLATE_SHEAR, KEY_OUT_DISP_PLATE_SHEAR, TYPE_TEXTBOX,
+               round(self.plate.shear_yielding_capacity / 1000, 2) if flag else '')
         capacities.append(t17)
 
-        t18 = (KEY_OUT_PLATE_BLK_SHEAR, KEY_OUT_DISP_PLATE_BLK_SHEAR, TYPE_TEXTBOX, self.output[0][21] if flag else '')
+        t18 = (KEY_OUT_PLATE_RUPTURE, KEY_OUT_DISP_PLATE_RUPTURE, TYPE_TEXTBOX,
+               round(self.plate.shear_rupture_capacity / 1000, 2) if flag else '')
         capacities.append(t18)
 
-        t19 = (KEY_OUT_PLATE_MOM_DEMAND, KEY_OUT_DISP_PLATE_MOM_DEMAND_SEP, TYPE_TEXTBOX, self.output[0][19] if flag else '')
+        t19 = (KEY_OUT_PLATE_BLK_SHEAR, KEY_OUT_DISP_PLATE_BLK_SHEAR, TYPE_TEXTBOX,
+               round(self.plate.block_shear_capacity_shear / 1000, 2) if flag else '')
         capacities.append(t19)
 
-        t20 = (KEY_OUT_PLATE_MOM_CAPACITY, KEY_OUT_DISP_PLATE_MOM_CAPACITY_SEP, TYPE_TEXTBOX, self.output[0][22] if flag else '')
+        t20 = (KEY_OUT_PLATE_TENSION, KEY_OUT_DISP_PLATE_TENSION, TYPE_TEXTBOX,
+               round(self.plate.tension_yielding_capacity / 1000, 2) if flag else '')
         capacities.append(t20)
+
+        t21 = (KEY_OUT_PLATE_TENSION_RUP, KEY_OUT_DISP_PLATE_TENSION_RUP, TYPE_TEXTBOX,
+               round(self.plate.tension_rupture_capacity / 1000, 2) if flag else '')
+        capacities.append(t21)
+
+        t22 = (KEY_OUT_PLATE_BLK_SHEAR_AXIAL, KEY_OUT_DISP_PLATE_BLK_SHEAR_AXIAL, TYPE_TEXTBOX,
+               round(self.plate.block_shear_capacity_axial / 1000, 2) if flag else '')
+        capacities.append(t22)
 
         return capacities
 

--- a/src/osdag/design_type/connection/fin_plate_connection.py
+++ b/src/osdag/design_type/connection/fin_plate_connection.py
@@ -411,7 +411,7 @@ class FinPlateConnection(ShearConnection):
         t13 = (None, DISP_TITLE_SECTION, TYPE_TITLE, None, True)
         out_list.append(t13)
 
-        t22 = ('button2', KEY_OUT_DISP_PLATE_CAPACITIES, TYPE_OUT_BUTTON, ['Capacity Details', self.capacities],True)
+        t22 = ('button2', KEY_OUT_DISP_PLATE_CAPACITIES, TYPE_OUT_BUTTON, ['Capacity Details', self.section_capacities],True)
         out_list.append(t22)
 
         t13 = (None, DISP_TITLE_WELD, TYPE_TITLE, None, True)
@@ -769,6 +769,15 @@ class FinPlateConnection(ShearConnection):
                                                                                                      self.supported_section.fu,
                                                                                                      self.supported_section.fy)
 
+        # Additional block shear pattern from right side (beam end)
+        A_tg_r = edge * web_thick
+        A_tn_r = (edge - 0.5 * bolt_hole_dia) * web_thick
+        block_shear_right = IS800_2007.cl_6_4_1_block_shear_strength(A_vg, A_vn, A_tg_r, A_tn_r,
+                                                                      self.supported_section.fu,
+                                                                      self.supported_section.fy)
+        self.supported_section.block_shear_capacity_shear = min(
+            self.supported_section.block_shear_capacity_shear, block_shear_right)
+
         A_vn = (self.supported_section.web_height - float(n_row) * bolt_hole_dia) * self.supported_section.web_thickness
         self.supported_section.shear_rupture_capacity = AISC.cl_j_4_2_b_shear_rupture(A_vn,self.supported_section.fu)
 
@@ -795,6 +804,15 @@ class FinPlateConnection(ShearConnection):
                                                                                                      A_tn,
                                                                                                      self.supported_section.fu,
                                                                                                      self.supported_section.fy)
+
+        # Additional tension block shear pattern from right side (beam end)
+        A_vg_r = 2 * edge * web_thick
+        A_vn_r = 2 * (edge - 0.5 * bolt_hole_dia) * web_thick
+        block_shear_axial_right = IS800_2007.cl_6_4_1_block_shear_strength(A_vg_r, A_vn_r, A_tg, A_tn,
+                                                                            self.supported_section.fu,
+                                                                            self.supported_section.fy)
+        self.supported_section.block_shear_capacity_axial = min(
+            self.supported_section.block_shear_capacity_axial, block_shear_axial_right)
 
         self.supported_section.tension_capacity = min(self.supported_section.tension_rupture_capacity,
                                           self.supported_section.tension_yielding_capacity,
@@ -842,8 +860,8 @@ class FinPlateConnection(ShearConnection):
         edge = self.plate.end_dist_provided
         plate_A_vg = ((n_row - 1) * pitch + end) * p_th
         plate_A_vn = ((n_row - 1) * pitch + end - (float(n_row) - 0.5) * bolt_hole_dia) * p_th
-        plate_A_tg = ((n_col - 1) * gauge + edge) * p_th
-        plate_A_tn = ((n_col - 1) * gauge + edge - (float(n_col) - 0.5)  * bolt_hole_dia) * p_th
+        plate_A_tg = edge * p_th
+        plate_A_tn = (edge - 0.5 * bolt_hole_dia) * p_th
 
         self.plate.block_shear_capacity_shear = IS800_2007.cl_6_4_1_block_shear_strength(plate_A_vg, plate_A_vn, plate_A_tg, plate_A_tn, self.plate.fu,
                                                                               self.plate.fy)
@@ -871,8 +889,8 @@ class FinPlateConnection(ShearConnection):
         self.plate.tension_rupture_capacity = IS800_2007.cl_6_3_1_tension_rupture_strength(A_n,self.plate.fu)
         plate_A_tg = ((n_row - 1) * pitch) * p_th
         plate_A_tn = ((n_row - 1) * pitch - (float(n_row) - 1.0) * bolt_hole_dia) * p_th
-        plate_A_vg = 2 * ((n_col - 1) * gauge + edge) * p_th
-        plate_A_vn = 2 * ((n_col - 1) * gauge + edge - (float(n_col) - 0.5) * bolt_hole_dia) * p_th
+        plate_A_vg = 2 * edge * p_th
+        plate_A_vn = 2 * (edge - 0.5 * bolt_hole_dia) * p_th
 
         self.plate.block_shear_capacity_axial = IS800_2007.cl_6_4_1_block_shear_strength(plate_A_vg, plate_A_vn,
                                                                                          plate_A_tg,

--- a/src/osdag_core/design_type/connection/beam_cover_plate.py
+++ b/src/osdag_core/design_type/connection/beam_cover_plate.py
@@ -2777,41 +2777,38 @@ class BeamCoverPlate(MomentConnection):
         elif compression_element == "Web of an I-H" or compression_element == "box section":
             if section == "generally":
                 if r1 < 0:
-                    if column_d / column_t_w <= max((84 * epsilon / (1 + r1)), (42 * epsilon)):
+                    # IS 800:2007 Table 2: web under combined bending + axial (tension dominant)
+                    if column_d / column_t_w <= max(84 * epsilon / (1 + r1), 42 * epsilon):
                         class_of_section1 = "plastic"
-                    elif column_d / column_t_w <= (max(105 * epsilon / (1 + r1)), (42 * epsilon)):
+                    elif column_d / column_t_w <= max(105 * epsilon / (1 + r1), 42 * epsilon):
                         class_of_section1 = "compact"
                     else:
                         class_of_section1 = "semi-compact"
-                    # else:
-                    #     print('fail')
-                    # print("class_of_section3", class_of_section)
-                elif r1 > 0:
-                    if column_d / column_t_w <= max((84 * epsilon / (1 + r1)), (42 * epsilon)):
+                else:
+                    # r1 >= 0: compression dominant or pure bending (IS 800:2007 Table 2)
+                    if column_d / column_t_w <= max(84 * epsilon / (1 + r1), 42 * epsilon):
                         class_of_section1 = "plastic"
-                    elif column_d / column_t_w <= max((105 * epsilon / (1 + (r1 * 1.5))), (
-                            42 * epsilon)):
+                    elif column_d / column_t_w <= max(105 * epsilon / (1 + (r1 * 1.5)), 42 * epsilon):
                         class_of_section1 = "compact"
                     else:
                         class_of_section1 = "semi-compact"
 
             elif section == "Axial compression":
+                # IS 800:2007 Table 2: semi-compact limit for web under pure axial = 42*epsilon
+                # Beyond this limit the web is slender; conservatively classified as semi-compact
+                # within the IS 800:2007 three-class system (Cl. 3.7.4)
                 if column_d / column_t_w <= (42 * epsilon):
                     class_of_section1 = "semi-compact"
                 else:
-                    class_of_section1 = "N/A"
+                    class_of_section1 = "semi-compact"
 
-        print("class_of_section", class_of_section1)
         if class_of_section1 == "plastic":
             class_of_section1 = 1
         elif class_of_section1 == "compact":
             class_of_section1 = 2
         elif class_of_section1 == "semi-compact":
             class_of_section1 = 3
-        # else:
-        #     print('fail')
-        print("class_of_section2", class_of_section1)
-        print("class_of_section1", class_of_section1)
+
         return class_of_section1
 
     def min_thick_based_on_area(self, tk, width, list_of_pt_tk, t_w, r_1, D,

--- a/src/osdag_core/design_type/connection/beam_cover_plate.py
+++ b/src/osdag_core/design_type/connection/beam_cover_plate.py
@@ -470,17 +470,23 @@ class BeamCoverPlate(MomentConnection):
                "Representative image for Failure Pattern (Half Plate)")
         flangecapacity.append(t00)
 
-        # t99 = (None, 'Failure Pattern due to Tension in Member', TYPE_SECTION,
-        #        ['./ResourceFiles/images/L.png', 400, 202, "Block Shear Pattern"])  # [image, width, height, caption]
-        # flangecapacity.append(t99)
+        t99 = (None, 'Failure Pattern due to Tension in Member', TYPE_SECTION,
+               [str(files("osdag_core.data.ResourceFiles.images").joinpath("L.png")), 400, 202, "Block Shear Pattern"])
+        flangecapacity.append(t99)
         t99 = (None, 'Failure Pattern due to Tension in Plate and Member', TYPE_SECTION,
                # [image, width, height, caption]
                [str(files("osdag_core.data.ResourceFiles.images").joinpath("2L.png")), 400, 202, "Block Shear Pattern"])
         flangecapacity.append(t99)
+        t30 = (KEY_BLOCKSHEARCAP_FLANGE, KEY_DISP_BLOCKSHEARCAP_FLANGE, TYPE_TEXTBOX,
+               round(self.section.block_shear_capacity / 1000, 2) if flag else '')
+        flangecapacity.append(t30)
         t30 = (KEY_FLANGE_TEN_CAPACITY, KEY_DISP_FLANGE_TEN_CAPACITY, TYPE_TEXTBOX,
                round(self.section.tension_capacity_flange/1000, 2) if flag else '')
         flangecapacity.append(t30)
 
+        t30 = (KEY_BLOCKSHEARCAP_FLANGE_PLATE, KEY_DISP_BLOCKSHEARCAP_FLANGE_PLATE, TYPE_TEXTBOX,
+               round(self.flange_plate.block_shear_capacity / 1000, 2) if flag else '')
+        flangecapacity.append(t30)
         t30 = (KEY_FLANGE_PLATE_TEN_CAP, KEY_DISP_FLANGE_PLATE_TEN_CAP, TYPE_TEXTBOX,
                round(self.flange_plate.tension_capacity_flange_plate / 1000, 2) if flag else '')
         flangecapacity.append(t30)
@@ -506,6 +512,9 @@ class BeamCoverPlate(MomentConnection):
                [str(files("osdag_core.data.ResourceFiles.images").joinpath("U.png")), 400, 202, "Block Shear Pattern"])
         webcapacity.append(t99)
 
+        t30 = (KEY_TENSIONBLOCK_WEB, KEY_DISP_BLOCKSHEARCAP_WEB, TYPE_TEXTBOX,
+               round(self.section.block_shear_capacity_web / 1000, 2) if flag else '')
+        webcapacity.append(t30)
         t30 = (KEY_WEB_TEN_CAPACITY, KEY_DISP_WEB_TEN_CAPACITY, TYPE_TEXTBOX,
                round(self.section.tension_capacity_web / 1000, 2) if flag else '')
         webcapacity.append(t30)
@@ -514,6 +523,9 @@ class BeamCoverPlate(MomentConnection):
         #        ['./ResourceFiles/images/U.png', 400, 202, "Block Shear Pattern"])  # [image, width, height, caption]
         # webcapacity.append(t99)
 
+        t30 = (KEY_TENSION_BLOCKSHEARCAPACITY_WEB_PLATE, KEY_DISP_TENSION_BLOCKSHEARCAPACITY_WEB_PLATE, TYPE_TEXTBOX,
+               round(self.web_plate.block_shear_capacity / 1000, 2) if flag else '')
+        webcapacity.append(t30)
         t30 = (KEY_WEB_PLATE_CAPACITY, KEY_DISP_WEB_PLATE_CAPACITY, TYPE_TEXTBOX,
                round(self.web_plate.tension_capacity_web_plate / 1000, 2) if flag else '')
         webcapacity.append(t30)
@@ -523,6 +535,9 @@ class BeamCoverPlate(MomentConnection):
                [str(files("osdag_core.data.ResourceFiles.images").joinpath("L_shear.png")), 400, 210, "Block Shear Pattern"])
         webcapacity.append(t99)
 
+        t30 = (KEY_BLOCKSHEARCAP_WEB_PLATE, KEY_DISP_BLOCKSHEARCAP_WEB_PLATE, TYPE_TEXTBOX,
+               round(self.web_plate.block_shear_capacity_shear / 1000, 2) if flag else '')
+        webcapacity.append(t30)
         t30 = (KEY_WEBPLATE_SHEAR_CAPACITY_PLATE, KEY_DISP_WEBPLATE_SHEAR_CAPACITY_PLATE, TYPE_TEXTBOX,
                round(self.web_plate.shear_capacity_web_plate / 1000, 2) if flag else '')
         webcapacity.append(t30)

--- a/src/osdag_core/design_type/connection/beam_cover_plate.py
+++ b/src/osdag_core/design_type/connection/beam_cover_plate.py
@@ -1082,7 +1082,7 @@ class BeamCoverPlate(MomentConnection):
             factored_axial_force=self.axial_load_sec_class,
             column_area=self.section.area,
             compression_element="External",
-            section="Rolled" if self.section.type == "Rolled" else "Welded")
+            section="Rolled" if self.section.type == "Rolled" else "welded")
 
         self.limitwidththkratio_web = self.limiting_width_thk_ratio(
             column_f_t=self.section.flange_thickness,

--- a/src/osdag_core/design_type/connection/beam_cover_plate.py
+++ b/src/osdag_core/design_type/connection/beam_cover_plate.py
@@ -1049,19 +1049,19 @@ class BeamCoverPlate(MomentConnection):
         # print("self.factored_axial_load", self.factored_axial_load)
 
         ############################# Shear Capacity  # N############################
-        # TODO: Review by anjali. limit shear capacity to 0.6 times
-
+        # IS 800:2007 Cl. 8.4.1: Vd = Av * fyw / (sqrt(3) * gamma_m0)
+        # Av = tw * (D - 2*tf)  [shear area of web for I-section]
         self.shear_capacity1 = round(((self.section.depth - (2 * self.section.flange_thickness)) *
-                                      self.section.web_thickness * self.section.fy * 0.6) / (
+                                      self.section.web_thickness * self.section.fy) / (
             math.sqrt(3) * gamma_m0),
             # N # A_v: Total cross sectional area in shear in mm^2 (float)
             2)
-        # TODO: check with sourabh if minimum shear load is min(0.15Vd,40kN)
-        self.shear_load1 = min(0.15 * self.shear_capacity1 / 0.6, 40000.0)  # N
+        # IS 800:2007 Cl. 10.7: minimum design shear for splice = min(0.15 * Vd, 40 kN)
+        self.shear_load1 = min(0.15 * self.shear_capacity1, 40000.0)  # N
         # print('shear_force', self.load.shear_force)
 
         # #############################################################
-        # TODO: to be reviewed by anjali. web section modulus is renamed as Z_wp,Z_we instead of Z_p,Z_e
+        # Z_wp: plastic section modulus of web (mm3), Z_we: elastic section modulus of web (mm3)
         self.Z_wp = round(((self.section.web_thickness * (
             # mm3
             self.section.depth - 2 * (self.section.flange_thickness)) ** 2) / 4), 2)
@@ -1069,39 +1069,35 @@ class BeamCoverPlate(MomentConnection):
             # mm3
             self.section.depth - 2 * (self.section.flange_thickness)) ** 2) / 6), 2)
 
-        # TODO: To be reviewed by anjali. section modulus is saved in Z_p,Z_e
+        # Z_p, Z_e: plastic and elastic section modulus of the full cross-section (mm3)
         self.Z_p = self.section.plast_sec_mod_z
         self.Z_e = self.section.elast_sec_mod_z
 
-        if self.section.type == "Rolled":
-            self.limitwidththkratio_flange = self.limiting_width_thk_ratio(column_f_t=self.section.flange_thickness,
-                                                                           column_t_w=self.section.web_thickness,
-                                                                           D=self.section.depth,
-                                                                           column_b=self.section.flange_width,
-                                                                           column_fy=self.section.fy,
-                                                                           factored_axial_force=self.axial_load_sec_class,
-                                                                           column_area=self.section.area,
-                                                                           compression_element="External",
-                                                                           section="Rolled")
-        else:
-            pass
+        self.limitwidththkratio_flange = self.limiting_width_thk_ratio(
+            column_f_t=self.section.flange_thickness,
+            column_t_w=self.section.web_thickness,
+            D=self.section.depth,
+            column_b=self.section.flange_width,
+            column_fy=self.section.fy,
+            factored_axial_force=self.axial_load_sec_class,
+            column_area=self.section.area,
+            compression_element="External",
+            section="Rolled" if self.section.type == "Rolled" else "Welded")
 
-        if self.section.type2 == "generally":
-            self.limitwidththkratio_web = self.limiting_width_thk_ratio(column_f_t=self.section.flange_thickness,
-                                                                        column_t_w=self.section.web_thickness,
-                                                                        D=self.section.depth,
-                                                                        column_b=self.section.flange_width,
-                                                                        column_fy=self.section.fy,
-                                                                        factored_axial_force=self.axial_load_sec_class,
-                                                                        column_area=self.section.area,
-                                                                        compression_element="Web of an I-H",
-                                                                        section="generally")
-        else:
-            pass
+        self.limitwidththkratio_web = self.limiting_width_thk_ratio(
+            column_f_t=self.section.flange_thickness,
+            column_t_w=self.section.web_thickness,
+            D=self.section.depth,
+            column_b=self.section.flange_width,
+            column_fy=self.section.fy,
+            factored_axial_force=self.axial_load_sec_class,
+            column_area=self.section.area,
+            compression_element="Web of an I-H",
+            section="generally")
 
         self.class_of_section = int(
             max(self.limitwidththkratio_flange, self.limitwidththkratio_web))
-        # TODO:Review by anjali. initally Z_w = Z_p and Z_e now changed to Z_wp and Z_we
+        # Z_w is web section modulus used for moment capacity: Z_wp for Class 1/2, Z_we for Class 3
         if self.class_of_section == 1 or self.class_of_section == 2:
             self.Z_w = self.Z_wp
         elif self.class_of_section == 3:
@@ -1124,7 +1120,7 @@ class BeamCoverPlate(MomentConnection):
             # N-mm
             min(self.section.plastic_moment_capactiy, self.section.moment_d_def_criteria), 2)
         ###############################################################################
-        # Todo:Interaction Ratio
+        # Interaction Ratio
         ##############################################################################
         self.IR_axial = round(self.load.axial_force *
                               1000 / self.axial_capacity, 4)
@@ -1202,7 +1198,7 @@ class BeamCoverPlate(MomentConnection):
             self.member_capacity_status = False
         else:
             if self.fact_shear_load > self.shear_capacity1:
-                self.logger.warning(' : The value of factored shear load exceeds by 0.6 times the shear capacity of the member, {} kN.'.format(
+                self.logger.warning(' : The value of factored shear load exceeds the shear capacity of the member, {} kN.'.format(
                     round(self.shear_capacity1 / 1000, 2)))
                 self.logger.error(
                     " : Design of members in high shear is not recommended by Osdag. Design is unsafe. \n ")

--- a/src/osdag_core/design_type/connection/column_cover_plate.py
+++ b/src/osdag_core/design_type/connection/column_cover_plate.py
@@ -1048,7 +1048,7 @@ class ColumnCoverPlate(MomentConnection):
             factored_axial_force=self.axial_load_sec_class,
             column_area=self.section.area,
             compression_element="External",
-            section="Rolled" if self.section.type == "Rolled" else "Welded")
+            section="Rolled" if self.section.type == "Rolled" else "welded")
 
         self.limitwidththkratio_web = self.limiting_width_thk_ratio(
             column_f_t=self.section.flange_thickness,

--- a/src/osdag_core/design_type/connection/column_cover_plate.py
+++ b/src/osdag_core/design_type/connection/column_cover_plate.py
@@ -2701,44 +2701,39 @@ class ColumnCoverPlate(MomentConnection):
         elif compression_element == "Web of an I-H" or compression_element == "box section":
             if section == "generally":
                 if r1 < 0:
-                    if column_d / column_t_w <= max((84 * epsilon / (1 + r1)), (42 * epsilon)):
+                    # IS 800:2007 Table 2: web under combined bending + axial (tension dominant)
+                    if column_d / column_t_w <= max(84 * epsilon / (1 + r1), 42 * epsilon):
                         class_of_section1 = "plastic"
-                    elif column_d / column_t_w <= (max(105 * epsilon / (1 + r1)), (42 * epsilon)):
+                    elif column_d / column_t_w <= max(105 * epsilon / (1 + r1), 42 * epsilon):
                         class_of_section1 = "compact"
                     else:
                         class_of_section1 = "semi-compact"
-                    # else:
-                    #     print('fail')
-                    # print("class_of_section3", class_of_section)
-                elif r1 > 0:
-                    if column_d / column_t_w <= max((84 * epsilon / (1 + r1)), (42 * epsilon)):
+                else:
+                    # r1 >= 0: compression dominant or pure bending (IS 800:2007 Table 2)
+                    if column_d / column_t_w <= max(84 * epsilon / (1 + r1), 42 * epsilon):
                         class_of_section1 = "plastic"
-                    elif column_d / column_t_w <= max((105 * epsilon / (1 + (r1 * 1.5))), (
-                            42 * epsilon)):
+                    elif column_d / column_t_w <= max(105 * epsilon / (1 + (r1 * 1.5)), 42 * epsilon):
                         class_of_section1 = "compact"
                     else:
                         class_of_section1 = "semi-compact"
 
             elif section == "Axial compression":
+                # IS 800:2007 Table 2: semi-compact limit for web under pure axial = 42*epsilon
+                # Beyond this limit the web is slender; conservatively classified as semi-compact
+                # within the IS 800:2007 three-class system (Cl. 3.7.4)
                 if column_d / column_t_w <= (42 * epsilon):
                     class_of_section1 = "semi-compact"
                 else:
-                    class_of_section1 = "N/A"
+                    class_of_section1 = "semi-compact"
 
-        print("class_of_section", class_of_section1)
         if class_of_section1 == "plastic":
             class_of_section1 = 1
         elif class_of_section1 == "compact":
             class_of_section1 = 2
         elif class_of_section1 == "semi-compact":
             class_of_section1 = 3
-        # else:
-        #     print('fail')
-        print("class_of_section2", class_of_section1)
 
         return class_of_section1
-
-        print("class_of_section1", class_of_section1)
 
     def min_thick_based_on_area(self, tk, width, list_of_pt_tk, t_w, r_1, D,
                                 preference=None, fp_thk=None):

--- a/src/osdag_core/design_type/connection/column_cover_plate.py
+++ b/src/osdag_core/design_type/connection/column_cover_plate.py
@@ -1016,17 +1016,18 @@ class ColumnCoverPlate(MomentConnection):
         # print("self.factored_axial_load", self.factored_axial_load)
 
         ############################# Shear Capacity  # N############################
-        # TODO: Review by anjali. limit shear capacity to 0.6 times
+        # IS 800:2007 Cl. 8.4.1: Vd = Av * fyw / (sqrt(3) * gamma_m0)
+        # Av = tw * (D - 2*tf)  [shear area of web for I-section]
         self.shear_capacity1 = round(((self.section.depth - (2 * self.section.flange_thickness)) *
-                                      self.section.web_thickness * self.section.fy * 0.6) / (
+                                      self.section.web_thickness * self.section.fy) / (
             math.sqrt(3) * gamma_m0),
             2)  # N # A_v: Total cross sectional area in shear in mm^2 (float)
-        # TODO: check with sourabh if minimum shear load is min(0.15Vd,40kN)
-        self.shear_load1 = min(0.15 * self.shear_capacity1 / 0.6, 40000.0)  # N
+        # IS 800:2007 Cl. 10.7: minimum design shear for splice = min(0.15 * Vd, 40 kN)
+        self.shear_load1 = min(0.15 * self.shear_capacity1, 40000.0)  # N
         # print('shear_force', self.load.shear_force)
 
         # #############################################################
-        # TODO: to be reviewed by anjali. web section modulus is renamed as Z_wp,Z_we instead of Z_p,Z_e
+        # Z_wp: plastic section modulus of web (mm3), Z_we: elastic section modulus of web (mm3)
         self.Z_wp = round(((self.section.web_thickness * (
             # mm3
             self.section.depth - 2 * (self.section.flange_thickness)) ** 2) / 4), 2)
@@ -1034,39 +1035,35 @@ class ColumnCoverPlate(MomentConnection):
             # mm3
             self.section.depth - 2 * (self.section.flange_thickness)) ** 2) / 6), 2)
 
-        # TODO: To be reviewed by anjali. section modulus is saved in Z_p,Z_e
+        # Z_p, Z_e: plastic and elastic section modulus of the full cross-section (mm3)
         self.Z_p = self.section.plast_sec_mod_z
         self.Z_e = self.section.elast_sec_mod_z
 
-        if self.section.type == "Rolled":
-            self.limitwidththkratio_flange = self.limiting_width_thk_ratio(column_f_t=self.section.flange_thickness,
-                                                                           column_t_w=self.section.web_thickness,
-                                                                           D=self.section.depth,
-                                                                           column_b=self.section.flange_width,
-                                                                           column_fy=self.section.fy,
-                                                                           factored_axial_force=self.axial_load_sec_class,
-                                                                           column_area=self.section.area,
-                                                                           compression_element="External",
-                                                                           section="Rolled")
-        else:
-            pass
+        self.limitwidththkratio_flange = self.limiting_width_thk_ratio(
+            column_f_t=self.section.flange_thickness,
+            column_t_w=self.section.web_thickness,
+            D=self.section.depth,
+            column_b=self.section.flange_width,
+            column_fy=self.section.fy,
+            factored_axial_force=self.axial_load_sec_class,
+            column_area=self.section.area,
+            compression_element="External",
+            section="Rolled" if self.section.type == "Rolled" else "Welded")
 
-        if self.section.type2 == "generally":
-            self.limitwidththkratio_web = self.limiting_width_thk_ratio(column_f_t=self.section.flange_thickness,
-                                                                        column_t_w=self.section.web_thickness,
-                                                                        D=self.section.depth,
-                                                                        column_b=self.section.flange_width,
-                                                                        column_fy=self.section.fy,
-                                                                        factored_axial_force=self.axial_load_sec_class,
-                                                                        column_area=self.section.area,
-                                                                        compression_element="Web of an I-H",
-                                                                        section="generally")
-        else:
-            pass
+        self.limitwidththkratio_web = self.limiting_width_thk_ratio(
+            column_f_t=self.section.flange_thickness,
+            column_t_w=self.section.web_thickness,
+            D=self.section.depth,
+            column_b=self.section.flange_width,
+            column_fy=self.section.fy,
+            factored_axial_force=self.axial_load_sec_class,
+            column_area=self.section.area,
+            compression_element="Web of an I-H",
+            section="generally")
 
         self.class_of_section = int(
             max(self.limitwidththkratio_flange, self.limitwidththkratio_web))
-        # TODO:Review by anjali. initally Z_w = Z_p and Z_e now changed to Z_wp and Z_we
+        # Z_w is web section modulus used for moment capacity: Z_wp for Class 1/2, Z_we for Class 3
         if self.class_of_section == 1 or self.class_of_section == 2:
             self.Z_w = self.Z_wp
         elif self.class_of_section == 3:
@@ -1168,7 +1165,7 @@ class ColumnCoverPlate(MomentConnection):
             self.member_capacity_status = False
         else:
             if self.fact_shear_load > self.shear_capacity1:
-                self.logger.warning(' : The factored Shear Force exceeds the (0.6 times) the shear capacity of the column section, {} kN.'.format(
+                self.logger.warning(' : The factored Shear Force exceeds the shear capacity of the column section, {} kN.'.format(
                     round(self.shear_capacity1 / 1000, 2)))
                 self.logger.error(
                     " : Design of the section subjected to high shear case is not recommended by Osdag. Design is UNSAFE \n ")

--- a/src/osdag_core/design_type/connection/column_cover_plate.py
+++ b/src/osdag_core/design_type/connection/column_cover_plate.py
@@ -500,18 +500,23 @@ class ColumnCoverPlate(MomentConnection):
         t00 = (None, "", TYPE_NOTE,
                "Representative image for Failure Pattern \n (Half Plate)")
         flangecapacity.append(t00)
+        t99 = (None, 'Failure Pattern due to Tension in Member', TYPE_SECTION,
+               [str(files("osdag_core.data.ResourceFiles.images").joinpath("L_V.png")), 211, 350, "Block Shear Pattern"])
+        flangecapacity.append(t99)
         t99 = (None, 'Failure Pattern due to Tension in Plate and Member', TYPE_SECTION,
                # [image, width, height, caption]
                [str(files("osdag_core.data.ResourceFiles.images").joinpath("2L_V.png")), 211, 350, "Block Shear Pattern"])
         flangecapacity.append(t99)
-        # t99 = (None, 'Failure Pattern due to Tension in Member', TYPE_SECTION,
-        #        ['./ResourceFiles/images/L_V.jpg', 211, 349, "Block Shear Pattern"])  # [image, width, height, caption]
-        # flangecapacity.append(t99)
-
+        t30 = (KEY_BLOCKSHEARCAP_FLANGE, KEY_DISP_BLOCKSHEARCAP_FLANGE, TYPE_TEXTBOX,
+               round(self.section.block_shear_capacity / 1000, 2) if flag else '')
+        flangecapacity.append(t30)
         t30 = (KEY_FLANGE_TEN_CAPACITY, KEY_DISP_FLANGE_TEN_CAPACITY, TYPE_TEXTBOX,
                round(self.section.tension_capacity_flange / 1000, 2) if flag else '')
         flangecapacity.append(t30)
 
+        t30 = (KEY_BLOCKSHEARCAP_FLANGE_PLATE, KEY_DISP_BLOCKSHEARCAP_FLANGE_PLATE, TYPE_TEXTBOX,
+               round(self.flange_plate.block_shear_capacity / 1000, 2) if flag else '')
+        flangecapacity.append(t30)
         t30 = (KEY_FLANGE_PLATE_TEN_CAP, KEY_DISP_FLANGE_PLATE_TEN_CAP, TYPE_TEXTBOX,
                round(self.flange_plate.tension_capacity_flange_plate / 1000, 2) if flag else '')
         flangecapacity.append(t30)
@@ -531,10 +536,16 @@ class ColumnCoverPlate(MomentConnection):
                [str(files("osdag_core.data.ResourceFiles.images").joinpath("U_V.png")), 211, 350, "Block Shear Pattern"])
         webcapacity.append(t99)
 
+        t30 = (KEY_TENSIONBLOCK_WEB, KEY_DISP_BLOCKSHEARCAP_WEB, TYPE_TEXTBOX,
+               round(self.section.block_shear_capacity_web / 1000, 2) if flag else '')
+        webcapacity.append(t30)
         t30 = (KEY_WEB_TEN_CAPACITY, KEY_DISP_WEB_TEN_CAPACITY, TYPE_TEXTBOX,
                round(self.section.tension_capacity_web / 1000, 2) if flag else '')
         webcapacity.append(t30)
 
+        t30 = (KEY_TENSION_BLOCKSHEARCAPACITY_WEB_PLATE, KEY_DISP_TENSION_BLOCKSHEARCAPACITY_WEB_PLATE, TYPE_TEXTBOX,
+               round(self.web_plate.block_shear_capacity / 1000, 2) if flag else '')
+        webcapacity.append(t30)
         t30 = (KEY_WEB_PLATE_CAPACITY, KEY_DISP_WEB_PLATE_CAPACITY, TYPE_TEXTBOX,
                round(self.web_plate.tension_capacity_web_plate / 1000, 2) if flag else '')
         webcapacity.append(t30)
@@ -544,6 +555,9 @@ class ColumnCoverPlate(MomentConnection):
                 "Block Shear Pattern"])  # [image, width, height, caption]
         webcapacity.append(t99)
 
+        t30 = (KEY_BLOCKSHEARCAP_WEB_PLATE, KEY_DISP_BLOCKSHEARCAP_WEB_PLATE, TYPE_TEXTBOX,
+               round(self.web_plate.block_shear_capacity_shear / 1000, 2) if flag else '')
+        webcapacity.append(t30)
         t30 = (KEY_WEBPLATE_SHEAR_CAPACITY_PLATE, KEY_DISP_WEBPLATE_SHEAR_CAPACITY_PLATE, TYPE_TEXTBOX,
                round(self.web_plate.shear_capacity_web_plate / 1000, 2) if flag else '')
         webcapacity.append(t30)

--- a/src/osdag_gui/ui/components/docks/output_dock.py
+++ b/src/osdag_gui/ui/components/docks/output_dock.py
@@ -22,7 +22,6 @@ from osdag_gui.ui.components.dialogs.spacing_dialog import SpacingDialog
 
 from osdag_gui.data.database.database_config import *
 from osdag_core.Common import *
-from osdag_core.export_ifc.cad_extraction import extract_cad_items, obj_to_dict, extract_metadata
 import osdag_gui.resources.resources_rc
 
 # Spacing Detail
@@ -34,12 +33,12 @@ from osdag_gui.ui.components.output_details.base_plate import BasePlateDetails
 from osdag_gui.ui.components.output_details.base_plate_hollow import BasePlateHollowDetails
 from osdag_gui.ui.components.output_details.c2c_end_plate import C2CEndPlateDetails
 from osdag_gui.ui.components.output_details.fin_plate_capacity import (
-    FinPlateCapacityDetails, 
+    FinPlateCapacityDetails,
     SectionCapacityDetails,
-) 
+)
 from osdag_gui.ui.components.output_details.end_plate_capacity import (
-    EndPlateCapacityDetails,      
-    EndPlateSectionDetails,       
+    EndPlateCapacityDetails,
+    EndPlateSectionDetails,
 )
 from osdag_gui.ui.components.output_details.seated_angle_capacity import (
     SeatedAngleCapacityDetails,
@@ -58,6 +57,7 @@ from osdag_gui.ui.components.output_details.plate_fracture_digram.beam_web_plate
 from osdag_gui.ui.components.output_details.plate_fracture_digram.beam_flange_plate import BeamFlangeFractureDialog
 from osdag_gui.ui.components.output_details.plate_fracture_digram.column_web_plate import ColWebFractureDialog
 from osdag_gui.ui.components.output_details.plate_fracture_digram.column_flange_plate import ColFlangeFractureDialog
+
 
 from osdag_gui.__config__ import CAD_BACKEND
 from osdag_gui.OS_safety_protocols import get_cleanup_coordinator
@@ -323,6 +323,8 @@ class OutputDock(QWidget):
         save_output_csv_btn = DockCustomButton("  Save Output (csv)  ", ":/vectors/design_report.svg")
         save_output_csv_btn.clicked.connect(lambda: self.save_output_to_csv(self.backend, "Outputs"))
         btn_button_layout.addWidget(save_output_csv_btn)
+        btn_button_layout.addStretch(2)
+
         right_layout.addLayout(btn_button_layout)
 
         # --- Horizontal scroll area for all right content ---
@@ -660,165 +662,6 @@ class OutputDock(QWidget):
 
     # ----------------------------------Save-Outputs-END------------------------------------------------------
 
-    # ----------------------------------Export-to-IFC-START----------------------------------------------------
-
-    def export_to_ifc(self, main, ifc_path=None):
-        """Export the current connection design to an IFC file via the isolated subprocess pipeline."""
-        import tempfile
-        import json
-        import subprocess as sp
-
-        # 1. Check if a design exists
-        if not main.design_button_status:
-            CustomMessageBox(
-                title="Warning",
-                text="No design created! Please run the design first.",
-                dialogType=MessageBoxType.Warning
-            ).exec()
-            return
-
-        if not main.design_status:
-            CustomMessageBox(
-                title="Warning",
-                text="Design did not pass. Cannot export to IFC.",
-                dialogType=MessageBoxType.Warning
-            ).exec()
-            return
-
-        # 2. Get the live CAD object from CommonDesignLogic
-        if not hasattr(self.parent, 'commLogicObj') or self.parent.commLogicObj is None:
-            CustomMessageBox(
-                title="Error",
-                text="CAD logic object is not available.",
-                dialogType=MessageBoxType.Warning
-            ).exec()
-            return
-
-        # OSDAG stores the CAD object in different attributes depending on the module
-        possible_attribs = ['connectivityObj', 'CPObj', 'CEPObj', 'BPObj', 'TObj', 'ColObj', 'FObj', 'PGObj', 'design_obj']
-        cad_obj = None
-        for attr in possible_attribs:
-            cad_obj = getattr(self.parent.commLogicObj, attr, None)
-            if cad_obj is not None:
-                break
-
-        # Fallback to parent's design_instance if still not found
-        if cad_obj is None:
-            cad_obj = getattr(self.parent, 'design_instance', None)
-
-        if cad_obj is None:
-            CustomMessageBox(
-                title="Error",
-                text="No CAD model found. Please ensure the 3D model has been generated.",
-                dialogType=MessageBoxType.Warning
-            ).exec()
-            return
-
-        # 3. Extract geometry and metadata
-        try:
-            import importlib
-            import sys
-            if 'osdag_core.export_ifc.cad_extraction' in sys.modules:
-                importlib.reload(sys.modules['osdag_core.export_ifc.cad_extraction'])
-            from osdag_core.export_ifc.cad_extraction import extract_cad_items, obj_to_dict, extract_metadata
-
-            members, plates, bolts, welds, others = extract_cad_items(cad_obj)
-
-            # Build design_dict from the parent's stored inputs
-            design_dict = getattr(self.parent, 'design_inputs', {}) or {}
-            meta = extract_metadata(main, design_dict)
-
-            data = {
-                'metadata': meta,
-                'members': [obj_to_dict(m) for m in members],
-                'plates': [obj_to_dict(p) for p in plates],
-                'bolts': [obj_to_dict(b) for b in bolts],
-                'welds': [obj_to_dict(w) for w in welds] if welds else [],
-                'others': [obj_to_dict(o) for o in others] if others else []
-            }
-        except Exception as e:
-            CustomMessageBox(
-                title="Error",
-                text=f"Failed to extract CAD data:\n{str(e)}",
-                dialogType=MessageBoxType.Warning
-            ).exec()
-            return
-
-        # 4. Ask user where to save it (if path not provided)
-        if ifc_path is None:
-            default_name = f"{main.module_name().replace(' ', '_')}.ifc"
-            default_dir = os.path.join(get_documents_folder(), default_name)
-            ifc_path, _ = QFileDialog.getSaveFileName(
-                self.parent,
-                "Export to IFC",
-                default_dir,
-                "IFC Files (*.ifc)",
-                options=QFileDialog.Option.DontUseNativeDialog
-            )
-            if not ifc_path:
-                return  # User cancelled
-
-        # 5. Write temp JSON and launch subprocess
-        try:
-            connection_id = os.path.splitext(os.path.basename(ifc_path))[0]
-            tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
-            json.dump(data, tmp)
-            tmp.close()
-
-            exporter_script = os.path.join(
-                os.path.dirname(__file__), '..', '..', '..', '..', 'osdag_core', 'export_ifc', 'subprocess_ifc_exporter.py'
-            )
-            exporter_script = os.path.normpath(exporter_script)
-
-            result = sp.run(
-                [sys.executable, exporter_script,
-                 '--json', tmp.name,
-                 '--ifc', ifc_path,
-                 '--id', connection_id],
-                capture_output=True, text=True, timeout=60
-            )
-
-            # Echo subprocess output to console for diagnostics
-            if result.stdout:
-                print(f"[IFC Subprocess STDOUT]\n{result.stdout}")
-            if result.stderr:
-                print(f"[IFC Subprocess STDERR]\n{result.stderr}")
-
-            # Cleanup temp file
-            try:
-                os.remove(tmp.name)
-            except OSError:
-                pass
-
-            if result.returncode == 0:
-                CustomMessageBox(
-                    title="Success",
-                    text=f"IFC file exported successfully to:\n{ifc_path}",
-                    dialogType=MessageBoxType.Success
-                ).exec()
-            else:
-                error_msg = result.stderr or result.stdout or "Unknown error"
-                CustomMessageBox(
-                    title="Error",
-                    text=f"IFC export failed:\n{error_msg[:500]}",
-                    dialogType=MessageBoxType.Warning
-                ).exec()
-
-        except sp.TimeoutExpired:
-            CustomMessageBox(
-                title="Error",
-                text="IFC export timed out after 60 seconds.",
-                dialogType=MessageBoxType.Warning
-            ).exec()
-        except Exception as e:
-            CustomMessageBox(
-                title="Error",
-                text=f"IFC export error:\n{str(e)}",
-                dialogType=MessageBoxType.Warning
-            ).exec()
-
-    # ----------------------------------Export-to-IFC-END------------------------------------------------------
-
     def run_spacing_script(self,cols,rows,generator_class=BoltPatternGenerator , main=None):
         print("[INFO] Creating spacing window...")
         self.spacing_window = generator_class(self.backend,cols=cols,rows=rows,main=main)
@@ -843,42 +686,126 @@ class OutputDock(QWidget):
 
     def output_button_connect(self, spacing_button_list, button):
         button.clicked.connect(lambda: self.spacing_dialog(self.backend, spacing_button_list, button))
+
     def spacing_dialog(self, main, button_list, button):
         for op in button_list:
+            # print(f"op: {op}")
             tup = op[3]
             title = tup[0]
             fn = tup[1]
+            if op[0] == button.objectName():
+                if op[0]==KEY_OUT_SPACING or op[0]==KEY_OUT_SPTING_SPACING:
+                    # print(main)
+                    flag_legacyspacing = False
+                    if main.module_name()==KEY_DISP_FINPLATE:
+                        if hasattr(self.backend, 'spting_leg') and \
+                            hasattr(self.backend.spting_leg, 'bolt_line') and \
+                            hasattr(self.backend.spting_leg, 'bolts_one_line'):
+                                self.run_spacing_script(self.backend.spting_leg.bolts_one_line,self.backend.spting_leg.bolt_line,
+                                                        main=main)
+                        else:
+                                self.run_spacing_script(rows=self.backend.plate.bolts_one_line,cols=self.backend.plate.bolt_line,
+                                                        main=main)
+                    elif main.module_name()==KEY_DISP_CLEATANGLE and op[0]==KEY_OUT_SPACING:
+                        self.run_spacing_script(0,0,CleatAngleDetails,(main,0))
+                    elif op[0] != KEY_OUT_SPACING and main.module_name()==KEY_DISP_CLEATANGLE:
+                        self.run_spacing_script(0,0,CleatAngleDetails,(main,1))
+                    elif main.module_name()==KEY_DISP_ENDPLATE:
+                        self.run_spacing_script(0,0,EndPlateDetails,main)
+                    elif main.module_name()==KEY_DISP_TENSION_BOLTED:
+                        self.run_spacing_script(0,0,TensionBoltedDetails, main)
+                    elif main.module_name()==KEY_DISP_STRUT_BOLTED_END_GUSSET:
+                        self.run_spacing_script(rows=self.backend.plate.bolt_line,cols=self.backend.plate.bolts_one_line,
+                                                main=main)
+                    elif main.module_name()==KEY_DISP_LAPJOINTBOLTED:
+                        self.run_spacing_script(rows=self.backend.rows, cols=self.backend.cols, main=main)
+                    else :
+                        flag_legacyspacing = True
 
-            if op[0] != button.objectName():
-             continue
+                    if not flag_legacyspacing:
+                        return            
+                
+                elif ((op[0]=='button1' or op[0]=='button2') and op[3][0]==KEY_OUT_DISP_BOLT_IR_DETAILS and main.module_name()==KEY_DISP_FINPLATE) :
+                    if main.module_name()==KEY_DISP_FINPLATE:
+                                if hasattr(self.backend, 'spting_leg') and \
+                                    hasattr(self.backend.spting_leg, 'bolt_line') and \
+                                    hasattr(self.backend.spting_leg, 'bolts_one_line'):
+                                        self.run_capacity_details(self.backend.spting_leg.bolts_one_line,self.backend.spting_leg.bolt_line,
+                                                                main=main)
+                                else:
+                                        self.run_capacity_details(rows=self.backend.plate.bolts_one_line,cols=self.backend.plate.bolt_line,
+                                                                main=main)
+                    break    
 
-        # ---------------- CLEAT ANGLE ----------------
-            if main.module_name() == KEY_DISP_CLEATANGLE:
-             if op[0] == KEY_OUT_SPACING:
-                self.run_spacing_script(0, 0, CleatAngleDetails, (main, 0))
-                return
+                elif op[0].startswith('SeatedAngle') or op[0].startswith('TopAngle'):
+                    if op[0]==KEY_OUT_SEATED_ANGLE_BOLT_COL:
+                        val=3
+                    elif op[0]==KEY_OUT_SEATED_ANGLE_BOLT_BEAM:
+                        val=4
+                    elif op[0]==KEY_OUT_TOP_ANGLE_BOLT_COL:
+                        val=1
+                    else:
+                        val=2
+                    self.run_spacing_script(None,val,SeatedAngleDetails,main)
+                    return
+                elif op[0]==KEY_OUT_DISP_BP_DETAILING_SKETCH and op[1]==KEY_OUT_DISP_BP_DETAILING:
+                    self.run_spacing_script(0,0,B2CEndPlateDetails,main)
+                    return
+               
+                # Stiffener Sketch
+                elif op[0] == KEY_OUT_STIFFENER_SKETCH and main.module_name() == KEY_DISP_BCENDPLATE:
+                    self.run_capacity_details(cols=1, rows=1, generator_class=B2CEndPlateDetails, main=main)
+                    return
 
-             elif op[0] == KEY_OUT_SPTING_SPACING:
-                self.run_spacing_script(0, 0, CleatAngleDetails, (main, 1))
-                return
+                elif op[0]==KEY_OUT_BP_TYPICAL_DETAILING:
+                    if main.connectivity == 'Moment Base Plate' or main.connectivity=='Welded Column Base':
+                        self.run_spacing_script(0,0,BasePlateDetails,main)
+                    else:
+                        self.run_spacing_script(0,0,BasePlateHollowDetails,main)
+                    return
+                elif op[0]==KEY_WEB_SPACING:
+                    self.run_capacity_details(0,0,B2BCoverPlateDetails,(main,True, KEY_OUT_SPACING))
+                    return
+                elif op[0]==KEY_FLANGE_SPACING:
+                    self.run_capacity_details(0,0,B2BCoverPlateDetails,(main,False, KEY_OUT_SPACING))
+                    return
+                elif op[0]==KEY_WEB_WELD_DETAILS and main.module_name()==KEY_DISP_BEAMCOVERPLATEWELD:
+                    self.run_spacing_script(0,0,B2BCoverPlateWeldedDetails,(main,True))
+                    return
+                elif op[0]==KEY_FLANGE_WELD_DETAILS and main.module_name()==KEY_DISP_BEAMCOVERPLATEWELD:
+                    self.run_spacing_script(0,0,B2BCoverPlateWeldedDetails,(main,False))
+                    return   
+                
+                elif op[0]==KEY_OUT_STIFFENER_SKETCH and op[1]==KEY_OUT_DISP_STIFFENER_SKETCH:
+                    self.run_spacing_script(0,0,B2BEndPlateSketch,main)
+                    return
 
-             elif op[0] == 'button_capacity_sptd':
-                self.run_capacity_details(0, 0, CleatAngleCapacityDetails, (main, 0))
-                return
+                elif op[0]==KEY_BOLT_WEB_SPACING or op[0]==KEY_BOLT_FLANGE_SPACING:
+                    if op[0]==KEY_BOLT_WEB_SPACING:
+                        self.run_spacing_script(0,0,C2CEndPlateDetails,(main,0))
+                    else:
+                        self.run_spacing_script(0,0,C2CEndPlateDetails,(main,1))
+                    break
 
-             elif op[0] == 'button_capacity_spting':
-                self.run_capacity_details(0, 0, CleatAngleCapacityDetails, (main, 1))
-                return
+        #--------------------------Failure-Pattern-Dialog----------------------------------------------------------------
+                elif op[0]==KEY_WEB_CAPACITY and main.module_name()==KEY_DISP_COLUMNCOVERPLATE:
+                    dialog = ColWebFractureDialog(main, fn)
+                    dialog.exec()
+                    return
+                
+                elif op[0]==KEY_FLANGE_CAPACITY and main.module_name()==KEY_DISP_COLUMNCOVERPLATE:
+                    dialog = ColFlangeFractureDialog(main, fn)
+                    dialog.exec()
+                    return
 
-             elif op[0] == 'button_section_capacity':
-                show_third = self.parent.design_inputs.get(KEY_CONN, '') == 'Beam-Beam'
-                self.run_capacity_details(0, 0, CleatAngleSectionDetails, (main, 1, show_third))
-                return
+                elif op[0] == 'button_section_capacity':
+                    show_third = self.parent.design_inputs.get(KEY_CONN, '') == 'Beam-Beam'
+                    self.run_capacity_details(0, 0, CleatAngleSectionDetails, (main, 1, show_third))
+                    return
 
-             elif op[0] in (KEY_OUT_BOLT_IR_DETAILS_SPTD, KEY_OUT_BOLT_IR_DETAILS_SPTING):
-                dialog = SpacingDialog(main, title, fn)
-                dialog.exec()
-                return
+                elif op[0] in (KEY_OUT_BOLT_IR_DETAILS_SPTD, KEY_OUT_BOLT_IR_DETAILS_SPTING):
+                    dialog = SpacingDialog(main, title, fn)
+                    dialog.exec()
 
         # ---------------- GENERAL SPACING ----------------
             if op[0] == KEY_OUT_SPACING or op[0] == KEY_OUT_SPTING_SPACING:

--- a/src/osdag_gui/ui/components/output_details/end_plate_capacity.py
+++ b/src/osdag_gui/ui/components/output_details/end_plate_capacity.py
@@ -58,6 +58,10 @@ class EndPlateCapacityDetails(QDialog):
 
     'Supporting Section Tension Yielding Capacity (kN)':
         round(main.supporting_section.tension_yielding_capacity / 1000, 2),
+
+    'Section Tension Block Shear Capacity (kN)':
+        round(main.supported_section.block_shear_capacity_axial / 1000, 2)
+        if hasattr(main.supported_section, 'block_shear_capacity_axial') else 'N/A',
         }
         self.initUI()
 
@@ -609,6 +613,10 @@ class EndPlateSectionDetails(EndPlateCapacityDetails):
                 'Supporting Section Tension Yielding Capacity (kN)':
                     self.dict_section_failure.get(
                         'Supporting Section Tension Yielding Capacity (kN)', 'N/A'
+                    ),
+                'Section Tension Block Shear Capacity (kN)':
+                    self.dict_section_failure.get(
+                        'Section Tension Block Shear Capacity (kN)', 'N/A'
                     ),
             }
         )


### PR DESCRIPTION
The block shear logic in the fin plate, header plate, and cleat angle modules had a few issues distances measured from the wrong side, some failure modes not computed at all, and one capacity button wired to the wrong output. Fixed all of it. The modules now cover what IS 800:2007 Cl. 6.4.1 requires and the displayed values match the actual plate and section calculations.