### PR TITLE
Fix: corrected stress unit to N/mm²

### DIFF
--- a/src/osdag_core/design_type/tension_member/tension_welded.py
+++ b/src/osdag_core/design_type/tension_member/tension_welded.py
@@ -617,7 +617,7 @@ class Tension_welded(Member):
             f"<b>Weld</b><br>"
             f"Size: {self.weld.size if flag else ''} mm<br>"
             f"Strength: {self.weld.strength if flag else ''} N/mm²<br>"
-            f"Stress: {self.weld.stress if flag else ''} N/mm<br>"
+            f"Stress: {self.weld.stress if flag else ''} N/mm²<br>"
             f"Eff. Length: {self.weld.length if flag else ''} mm"
         )
 


### PR DESCRIPTION
### Fix: Stress Unit in Tension Welded Module
- Corrected unit display from N/mm to N/mm²