### PR TITLE
feat: Move Floating navbar from CustomWindow to MainWindow

### DIFF
--- a/src/osdag_gui/main_window.py
+++ b/src/osdag_gui/main_window.py
@@ -22,11 +22,12 @@ from PySide6.QtWidgets import (
     QMainWindow, QTabBar, QTabWidget, QLabel, QTextBrowser, QScrollArea, QDialog
 )
 from PySide6.QtSvgWidgets import QSvgWidget
-from PySide6.QtCore import Qt, QSize, QEvent, QTimer, QPoint, QRect
-from PySide6.QtGui import QIcon, QGuiApplication, QPixmap, QPainter, QColor
+from PySide6.QtCore import Qt, QSize, QEvent, QTimer, QPoint, QRect, QPropertyAnimation
+from PySide6.QtGui import QIcon, QGuiApplication, QPixmap, QPainter, QColor, QCursor
 
 from osdag_gui.ui.windows.home_window import HomeWindow
 from osdag_gui.ui.windows.template_page import CustomWindow
+from osdag_gui.ui.components.floating_nav_bar import SidebarWidget
 from osdag_gui.ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
 from osdag_gui.ui.components.dialogs.settings import SettingsDialog
 
@@ -265,6 +266,7 @@ class MainWindow(QMainWindow):
 
         # Initialize UI first, as sidebar will overlay it
         self.init_ui() # Call init_ui before sidebar creation to ensure main content exists
+        self._create_sidebar()
         self.handle_add_tab("Home")
 
         # Using QTimer to delay maximizing until after the window is fully initialized
@@ -277,6 +279,7 @@ class MainWindow(QMainWindow):
     def init_ui(self):
         # Main Vertical Layout for the entire window's *content*
         central_widget = QWidget()
+        self.central_widget = central_widget
         self.setCentralWidget(central_widget)
         main_v_layout = QVBoxLayout(central_widget)
         main_v_layout.setContentsMargins(1, 0, 1, 1)
@@ -411,6 +414,81 @@ class MainWindow(QMainWindow):
         # Ensure initial synchronization
         if self.tab_bar.count() > 0:
             self.tab_widget.setCurrentIndex(self.tab_bar.currentIndex())
+
+    # ============= Floating sidebar (single persistent overlay) =============
+    def _create_sidebar(self):
+        """Create the floating module-shortcut sidebar as a single overlay on top of tab_widget."""
+        self.sidebar = SidebarWidget(parent=self)
+        self.sidebar.openNewTab.connect(self.handle_add_tab)
+        self.sidebar.resize_sidebar(self.width(), self.height())
+        self.sidebar_y = self.title_bar.height() + (self.tab_widget.height() - self.sidebar.height()) // 2
+        self.sidebar.move(-self.sidebar.width() + 12, self.sidebar_y)
+        self.sidebar_animation = QPropertyAnimation(self.sidebar, b"geometry")
+        self.sidebar_animation.setDuration(150)
+        self.sidebar.setAttribute(Qt.WA_DontCreateNativeAncestors, True)
+        self.sidebar.setWindowFlags(
+            Qt.Tool | Qt.FramelessWindowHint
+        )
+        self.sidebar.show()
+        self.sidebar.raise_()
+
+        # Hover is detected by polling the global cursor position rather than
+        # relying on Enter/Leave events, since the sidebar overlays tab content
+        # (e.g. the native CAD viewer) which can swallow those events first.
+        self._sidebar_expanded = False
+        self.sidebar_hover_timer = QTimer(self)
+        self.sidebar_hover_timer.setInterval(100)
+        self.sidebar_hover_timer.timeout.connect(self._check_sidebar_hover)
+        self.sidebar_hover_timer.start()
+
+    def _check_sidebar_hover(self):
+        if not self.sidebar.isVisible():
+            return
+        local_pos = self.mapFromGlobal(QCursor.pos())
+        hot_zone  = QRect(0, self.title_bar.height() + (self.tab_widget.height() - self.sidebar.height()) // 2, 12, self.sidebar.height())
+        sidebar_rect = self.sidebar.geometry()
+        inside = hot_zone.contains(local_pos) or sidebar_rect.contains(local_pos)
+        if inside and not self._sidebar_expanded:
+            self._sidebar_expanded = True
+            self.slide_in()
+        elif not inside and self._sidebar_expanded:
+            self._sidebar_expanded = False
+            self.slide_out()
+
+    def slide_in(self):
+        self.sidebar_animation.stop()
+        end_x = 5
+        top_offset = self.sidebar_y
+        self.sidebar_animation.setStartValue(self.sidebar.geometry())
+        self.sidebar_animation.setEndValue(QRect(end_x, top_offset, self.sidebar.width(), self.sidebar.height()))
+        self.sidebar_animation.start()
+        self.sidebar.raise_()
+
+    def slide_out(self):
+        self.sidebar_animation.stop()
+        end_x = -self.sidebar.width() + 12
+        top_offset = self.sidebar_y
+        self.sidebar_animation.setStartValue(self.sidebar.geometry())
+        self.sidebar_animation.setEndValue(QRect(end_x, top_offset, self.sidebar.width(), self.sidebar.height()))
+        self.sidebar_animation.start()
+
+    def _update_sidebar_visibility(self):
+        """Show the floating sidebar only on module (CustomWindow) tabs, hide it on the Home tab."""
+        if not hasattr(self, 'sidebar'):
+            return
+        if isinstance(self.main_widget_instance, CustomWindow):
+            self.sidebar.resize_sidebar(self.width(), self.height())
+            self.sidebar_y = self.title_bar.height() + (self.tab_widget.height() - self.sidebar.height()) // 2
+            self.sidebar_animation.stop()
+            self._sidebar_expanded = False
+            self.sidebar.move(-self.sidebar.width() + 12, self.sidebar_y)
+            self.sidebar.setVisible(True)
+            self.sidebar.raise_()
+        else:
+            self.sidebar_animation.stop()
+            self._sidebar_expanded = False
+            self.sidebar.setVisible(False)
+    # ============= Floating sidebar ends =============
 
     # Show the control button location popup
     def show_button_position_dialog(self):
@@ -749,6 +827,7 @@ class MainWindow(QMainWindow):
                     widget = widget_item.widget()
                     if widget is not None:
                         self.main_widget_instance = widget
+                        self._update_sidebar_visibility()
             # Update main_widget_layout to the layout of the current tab's body_widget
             if hasattr(body_widget, 'layout'):
                 self.main_widget_layout = body_widget.layout()
@@ -919,7 +998,7 @@ class MainWindow(QMainWindow):
                     widget.hide()
                     
                     # Disconnect specific signals if they exist
-                    signals = ['openNewTab', 'downloadDatabase', 'triggerLoadOsi',
+                    signals = ['downloadDatabase', 'triggerLoadOsi',
                             'openProject', 'openModule', 'cardOpenClicked']
                     
                     for sig in signals:
@@ -1070,6 +1149,7 @@ class MainWindow(QMainWindow):
         if hasattr(body_widget, 'layout') and body_widget.layout().count() > 0:
             widget = body_widget.layout().itemAt(0).widget()
             self.main_widget_instance = widget
+            self._update_sidebar_visibility()
         # Ensure main_widget_layout points to the currently active tab's layout
         if hasattr(body_widget, 'layout'):
             self.main_widget_layout = body_widget.layout()
@@ -1282,6 +1362,18 @@ class MainWindow(QMainWindow):
                     return True
         return super().eventFilter(obj, event)
 
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        if not hasattr(self, 'sidebar'):
+            return
+        self.sidebar.resize_sidebar(self.width(), self.height())
+        self.sidebar_y = self.title_bar.height() + (self.tab_widget.height() - self.sidebar.height()) // 2
+        if self.sidebar.x() < 0:
+            self.sidebar.move(-self.sidebar.width() + 12, self.sidebar_y)
+        else:
+            self.sidebar.move(self.sidebar.x(), self.sidebar_y)
+        self.sidebar.raise_()
+
     def configure_dwm_rendering(self, hwnd, background_color_rgb):
         if IS_WINDOWS:
             margins = ctypes.c_int * 4
@@ -1429,8 +1521,8 @@ class MainWindow(QMainWindow):
         # Load the last Design Inputs-end------------------------------------
 
         self.main_widget_instance = template_page
-        template_page.openNewTab.connect(self.handle_add_tab)
         template_page.downloadDatabase.connect(self.download_Database)
+        self._update_sidebar_visibility()
         self.main_widget_layout.addWidget(template_page)
         
         index = self.tab_bar.currentIndex()
@@ -1620,6 +1712,7 @@ class MainWindow(QMainWindow):
         home_window.downloadDatabase.connect(self.download_Database)
         home_window.importSection.connect(self.import_section)
         self.main_widget_instance = home_window
+        self._update_sidebar_visibility()
         home_window.set_active_button(module)
         home_window.cardOpenClicked.connect(self.handle_card_open_clicked)
         self.main_widget_layout.addWidget(home_window)

--- a/src/osdag_gui/ui/components/floating_nav_bar.py
+++ b/src/osdag_gui/ui/components/floating_nav_bar.py
@@ -69,6 +69,7 @@ class SidebarIconButton(QPushButton):
         return super().paintEvent(event)
 
     def mousePressEvent(self, event):
+        print(f"[BUTTON] pressEvent: {self.custom_tooltip_text}")
         if self.group:
             for btn in self.group:
                 if btn != self:
@@ -87,6 +88,7 @@ class SidebarIconButton(QPushButton):
         super().mousePressEvent(event)
 
     def enterEvent(self, event):
+        print(f"[BUTTON] enterEvent: {self.custom_tooltip_text}")
         if not self.is_selected:
             self.set_selected_style()
             self.setIcon(self.hover_icon)
@@ -95,6 +97,7 @@ class SidebarIconButton(QPushButton):
         super().enterEvent(event)
 
     def leaveEvent(self, event):
+        print(f"[BUTTON] leaveEvent: {self.custom_tooltip_text}")
         if not self.is_selected:
             self.set_default_style()
             if self.theme.is_light():
@@ -217,3 +220,11 @@ class SidebarWidget(QWidget):
         """Called when the widget is shown."""
         super().showEvent(event)
         self.update_responsive_elements()
+    
+    def enterEvent(self, event):
+        print("[SIDEBAR] SidebarWidget enterEvent")
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        print("[SIDEBAR] SidebarWidget leaveEvent")
+        super().leaveEvent(event)

--- a/src/osdag_gui/ui/windows/template_page.py
+++ b/src/osdag_gui/ui/windows/template_page.py
@@ -7,11 +7,10 @@ from PySide6.QtWidgets import (
     QMenuBar, QSplitter, QSizePolicy, QDialog, QLabel
 )
 from PySide6.QtSvgWidgets import QSvgWidget
-from PySide6.QtCore import Qt, QPoint, QRect, QPropertyAnimation, QEvent, Signal, QTimer
+from PySide6.QtCore import Qt, QPoint, QRect, Signal, QTimer
 from PySide6.QtGui import QKeySequence, QAction, QColor, QBrush, QPixmap, QCursor
 from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
 
-from osdag_gui.ui.components.floating_nav_bar import SidebarWidget
 from osdag_gui.ui.components.docks.input_dock import InputDock
 from osdag_gui.ui.components.docks.output_dock import OutputDock
 from osdag_gui.ui.components.docks.log_dock import LogDock
@@ -35,7 +34,6 @@ from osdag_gui.ui.components.custom_3dviewer import NavMode
 
 
 class CustomWindow(QWidget):
-    openNewTab = Signal(str)
     downloadDatabase = Signal(str, str)
     importSection = Signal(str)
     def __init__(self, title: str, backend: object, id:int, parent):
@@ -85,18 +83,7 @@ class CustomWindow(QWidget):
         self.designPrefDialog.ui.refreshAdditionalDesignation.connect(self.refresh_additional_input_designation)
 
         self.init_ui(title, id)
-        self.sidebar = SidebarWidget(parent=self)
-        self.sidebar.openNewTab.connect(self.openNewTabEmit)
-        self.sidebar.resize_sidebar(self.width(), self.height())
-        # Center sidebar vertically within the content area (below menu bar)
-        self.sidebar_y = self.height()//2 - self.sidebar.height()//4
-        self.sidebar.move(-self.sidebar.width() + 12, self.sidebar_y)
-        self.sidebar_animation = QPropertyAnimation(self.sidebar, b"geometry")
-        self.sidebar_animation.setDuration(150)
-        self.sidebar.setAttribute(Qt.WA_DontCreateNativeAncestors, True)
-        self.sidebar.installEventFilter(self)
-        self.sidebar.raise_()
-    
+
     def downloadDatabaseEmit(self, table, call_type):
         self.downloadDatabase.emit(table, call_type)
         
@@ -497,40 +484,6 @@ class CustomWindow(QWidget):
     
     #---------------------------------CAD-SETUP-END----------------------------------------------
     
-    def openNewTabEmit(self, title: str):
-        self.openNewTab.emit(title)
-
-    def eventFilter(self, watched, event):
-        #----- Don't block native events - let them propagate to MainWindow ----------
-        if event.type() in (QEvent.WinIdChange, QEvent.WindowActivate, 
-                       QEvent.WindowDeactivate, QEvent.FocusIn, QEvent.FocusOut):
-            return False
-        #----------------------------------------------------------------------------
-        
-        if watched == self.sidebar:
-            if event.type() == QEvent.Enter:
-                self.slide_in()
-            elif event.type() == QEvent.Leave:
-                self.slide_out()
-        return super().eventFilter(watched, event)
-
-    def slide_in(self):
-        self.sidebar_animation.stop()
-        end_x = 5
-        top_offset = self.sidebar_y
-        self.sidebar_animation.setStartValue(self.sidebar.geometry())
-        self.sidebar_animation.setEndValue(QRect(end_x, top_offset, self.sidebar.width(), self.sidebar.height()))
-        self.sidebar_animation.start()
-        self.sidebar.raise_()
-
-    def slide_out(self):
-        self.sidebar_animation.stop()
-        end_x = -self.sidebar.width() + 12
-        top_offset = self.sidebar_y
-        self.sidebar_animation.setStartValue(self.sidebar.geometry())
-        self.sidebar_animation.setEndValue(QRect(end_x, top_offset, self.sidebar.width(), self.sidebar.height()))
-        self.sidebar_animation.start()
-
     def init_ui(self, title: str, id: int):
         # Docking icons Parent class
         class ClickableSvgWidget(QSvgWidget):
@@ -1182,16 +1135,6 @@ class CustomWindow(QWidget):
         
         # Check if splitter exists and has children
         try:
-            # Normal Resize Event
-            self.sidebar.resize_sidebar(self.width(), self.height())
-            # Update sidebar position to keep it centered vertically
-            self.sidebar_y = (self.height() - self.menu_bar.height() - self.sidebar.height()) // 2 + self.menu_bar.height()
-            top_offset = self.sidebar_y
-            if self.sidebar.x() < 0:
-                self.sidebar.move(-self.sidebar.width() + 12, top_offset)
-            else:
-                self.sidebar.move(self.sidebar.x(), top_offset)
-                
             if not hasattr(self, 'splitter') or self.splitter is None:
                 return
             if self.splitter.count() < 3:
@@ -1223,7 +1166,6 @@ class CustomWindow(QWidget):
             self.splitter.refresh()
             self.body_widget.layout().activate()
             self.splitter.update()
-            self.sidebar.raise_()
             super().resizeEvent(event)
             
         except (IndexError, RuntimeError, AttributeError):


### PR DESCRIPTION
Moves SidebarWidget ownership from CustomWindow (per-tab) to MainWindow 
(single persistent instance), eliminating the duplicate sidebar conflict 
that caused hover and click events to be intercepted by hidden sidebar 
instances on tab switches.

Changes:
- Remove SidebarWidget creation, animation, and eventFilter handling 
  from CustomWindow.__init__
- Add _create_sidebar(), _check_sidebar_hover(), slide_in(), slide_out(), 
  and _update_sidebar_visibility() to MainWindow
- Sidebar visibility toggled via _update_sidebar_visibility() on tab 
  change — visible only on CustomWindow tabs, hidden on Home
- Hover detection via QTimer polling (100ms) instead of Enter/Leave 
  events, which are unreliable over the native OCC CAD viewer
- Remove openNewTab signal from CustomWindow (now handled directly by 
  MainWindow sidebar)