### PR TITLE
refactor: convert absolute imports to relative in osdag_gui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Output_PDF/*
 *.code-workspace
 **/testing_code/
 !license-dependencies.txt
+convert_imports.py
+fix_relative_imports.py
+verify_imports.py

--- a/src/osdag_gui/OS_safety_protocols/cleanup_coordinator.py
+++ b/src/osdag_gui/OS_safety_protocols/cleanup_coordinator.py
@@ -68,7 +68,7 @@ class CleanupCoordinator:
         
         # Import AISContextLock for thread-safe context operations
         try:
-            from osdag_gui.OS_safety_protocols import AISContextLock
+            from ..OS_safety_protocols import AISContextLock
             ais_lock_available = True
         except ImportError:
             ais_lock_available = False
@@ -98,7 +98,7 @@ class CleanupCoordinator:
 
             # Step 5: OCCMemoryManager safe cleanup
             try:
-                from osdag_gui.OS_safety_protocols import get_occ_memory_manager
+                from ..OS_safety_protocols import get_occ_memory_manager
                 manager = get_occ_memory_manager()
                 widget_id = id(cad_widget)
                 context = display.Context if display else None

--- a/src/osdag_gui/OS_safety_protocols/cleanup_coordinator.py
+++ b/src/osdag_gui/OS_safety_protocols/cleanup_coordinator.py
@@ -68,7 +68,7 @@ class CleanupCoordinator:
         
         # Import AISContextLock for thread-safe context operations
         try:
-            from ..OS_safety_protocols import AISContextLock
+            from . import AISContextLock
             ais_lock_available = True
         except ImportError:
             ais_lock_available = False
@@ -98,7 +98,7 @@ class CleanupCoordinator:
 
             # Step 5: OCCMemoryManager safe cleanup
             try:
-                from ..OS_safety_protocols import get_occ_memory_manager
+                from . import get_occ_memory_manager
                 manager = get_occ_memory_manager()
                 widget_id = id(cad_widget)
                 context = display.Context if display else None

--- a/src/osdag_gui/__main__.py
+++ b/src/osdag_gui/__main__.py
@@ -29,7 +29,7 @@ QApplication.setAttribute(Qt.ApplicationAttribute.AA_DontUseNativeDialogs, True)
 from osdag_core.utils.internet_connectivity import InternetConnectivity
 from .ui.windows.launch_screen import OsdagLaunchScreen
 from .ui.utils.theme_manager import ThemeManager
-import osdag_gui.resources.resources_rc
+from .resources import resources_rc
 import sys, click, os
 from pathlib import Path
 

--- a/src/osdag_gui/__main__.py
+++ b/src/osdag_gui/__main__.py
@@ -11,7 +11,7 @@ Startup sequence:
 # =============================================================================
 # CRITICAL: Import and run safety protocols BEFORE any PySide6/Qt imports
 # =============================================================================
-from osdag_gui.OS_safety_protocols import setup_environment, ensure_safe_startup
+from .OS_safety_protocols import setup_environment, ensure_safe_startup
 
 setup_environment()
 ensure_safe_startup()
@@ -27,8 +27,8 @@ from PySide6.QtGui import QFontDatabase, QFont, QIcon
 # This is critical for Linux systems with Intel/Mesa graphics drivers
 QApplication.setAttribute(Qt.ApplicationAttribute.AA_DontUseNativeDialogs, True)
 from osdag_core.utils.internet_connectivity import InternetConnectivity
-from osdag_gui.ui.windows.launch_screen import OsdagLaunchScreen
-from osdag_gui.ui.utils.theme_manager import ThemeManager
+from .ui.windows.launch_screen import OsdagLaunchScreen
+from .ui.utils.theme_manager import ThemeManager
 import osdag_gui.resources.resources_rc
 import sys, click, os
 from pathlib import Path
@@ -133,7 +133,7 @@ class LoadingThread(QThread):
     def run(self):
         import time
         # database_config also imports common.py which can also cause empty Material list issue
-        from osdag_gui.data.database.database_config import refactor_database, create_user_database
+        from .data.database.database_config import refactor_database, create_user_database
         # Create user database if not exist
         create_user_database()
         # Clean up user database to ensure 10 records and atmost 60 days older with path exist
@@ -179,7 +179,7 @@ def show_crash_dialog(reason, excecption, logfile):
 
 
 def gui():
-    from osdag_gui.error_handler import CrashLogger, TerminalLogger
+    from .error_handler import CrashLogger, TerminalLogger
 
     # set app directory
     user_docs = os.path.join(Path.home(), "Documents")
@@ -217,7 +217,7 @@ def gui():
         app.setStyleSheet(stylesheet)
     
     def show_main_window():
-        from osdag_gui.main_window import MainWindow
+        from .main_window import MainWindow
         app.internet_connectivity = InternetConnectivity() # --- Internet Connectivity object ---
         # Parallely load the MainWindow
         app.main_window = MainWindow()

--- a/src/osdag_gui/error_handler.py
+++ b/src/osdag_gui/error_handler.py
@@ -264,7 +264,7 @@ class CrashLogger:
                 except Exception:
                     pass
 
-from osdag_gui.ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from .ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
 class TerminalLogger:
     def __init__(self, log_dir=None):
 

--- a/src/osdag_gui/main_window.py
+++ b/src/osdag_gui/main_window.py
@@ -25,13 +25,13 @@ from PySide6.QtSvgWidgets import QSvgWidget
 from PySide6.QtCore import Qt, QSize, QEvent, QTimer, QPoint, QRect
 from PySide6.QtGui import QIcon, QGuiApplication, QPixmap, QPainter, QColor
 
-from osdag_gui.ui.windows.home_window import HomeWindow
-from osdag_gui.ui.windows.template_page import CustomWindow
-from osdag_gui.ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
-from osdag_gui.ui.components.dialogs.settings import SettingsDialog
+from .ui.windows.home_window import HomeWindow
+from .ui.windows.template_page import CustomWindow
+from .ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from .ui.components.dialogs.settings import SettingsDialog
 
-from osdag_gui.data.database.database_config import PROJECT_PATH, ID, update_project_path, delete_project_record
-from osdag_gui.data.database.database_config import get_module_function
+from .data.database.database_config import PROJECT_PATH, ID, update_project_path, delete_project_record
+from .data.database.database_config import get_module_function
 from osdag_core.Common import (
     KEY_DISP_FINPLATE, KEY_DISP_CLEATANGLE, KEY_DISP_ENDPLATE, KEY_DISP_SEATED_ANGLE,
     KEY_DISP_BCENDPLATE, KEY_DISP_BEAMCOVERPLATE, KEY_DISP_BEAMCOVERPLATEWELD, KEY_DISP_BB_EP_SPLICE,
@@ -42,7 +42,7 @@ from osdag_core.Common import (
     KEY_DISP_BASE_PLATE, KEY_MODULE, PATH_TO_DATABASE, get_documents_folder, get_db_header
 )
 # Backend Class Imports
-from osdag_gui.OS_safety_protocols import get_cleanup_coordinator
+from .OS_safety_protocols import get_cleanup_coordinator
 import openpyxl
 import platform
 import ctypes
@@ -932,7 +932,7 @@ class MainWindow(QMainWindow):
                     
                     # Use CleanupCoordinator for safe cleanup
                     # This replaces the legacy graveyard/setParent(None) logic
-                    from osdag_gui.OS_safety_protocols import get_cleanup_coordinator
+                    from .OS_safety_protocols import get_cleanup_coordinator
                     coordinator = get_cleanup_coordinator()
                     
                     # If the widget has CAD capability, treat it carefully
@@ -998,7 +998,7 @@ class MainWindow(QMainWindow):
             try:
                 # Use AISContextLock if available to prevent race conditions
                 try:
-                    from osdag_gui.OS_safety_protocols import AISContextLock
+                    from .OS_safety_protocols import AISContextLock
                     with AISContextLock():
                         coordinator = get_cleanup_coordinator()
                         coordinator.cleanup_for_tab_close(template_instance)
@@ -1028,7 +1028,7 @@ class MainWindow(QMainWindow):
             Skips CustomViewer3d to prevent OCC heap corruption.
             """
             from PySide6.QtWidgets import QWidget
-            from osdag_gui.ui.components.custom_3dviewer import CustomViewer3d
+            from .ui.components.custom_3dviewer import CustomViewer3d
             
             # Get all immediate children
             children = widget.children()

--- a/src/osdag_gui/main_window.py
+++ b/src/osdag_gui/main_window.py
@@ -2014,7 +2014,7 @@ class MainWindow(QMainWindow):
 
 # if __name__ == "__main__":
 #     import sys, os
-#     from osdag_gui.ui.utils.theme_manager import ThemeManager
+#     .ui.utils.theme_manager import ThemeManager
 #     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 #     from PySide6.QtWidgets import QApplication
 #     app = QApplication(sys.argv)

--- a/src/osdag_gui/main_window.py
+++ b/src/osdag_gui/main_window.py
@@ -12,7 +12,7 @@ Main application window for Osdag GUI.
 Handles tab management, docking icons, and main window controls.
 """
 
-import osdag_gui.resources.resources_rc
+from .resources import resources_rc
 
 import sys, sqlite3
 import os, yaml

--- a/src/osdag_gui/ui/components/additional_inputs_button.py
+++ b/src/osdag_gui/ui/components/additional_inputs_button.py
@@ -4,7 +4,7 @@ Simple clickable button with clean styling.
 """
 from PySide6.QtWidgets import QPushButton
 from PySide6.QtCore import Qt, Signal
-from ...ui.utils.custom_cursors import pointing_hand_cursor
+from ..utils.custom_cursors import pointing_hand_cursor
 
 class AdditionalInputsButton(QPushButton):
     button_clicked = Signal()

--- a/src/osdag_gui/ui/components/additional_inputs_button.py
+++ b/src/osdag_gui/ui/components/additional_inputs_button.py
@@ -4,7 +4,7 @@ Simple clickable button with clean styling.
 """
 from PySide6.QtWidgets import QPushButton
 from PySide6.QtCore import Qt, Signal
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ...ui.utils.custom_cursors import pointing_hand_cursor
 
 class AdditionalInputsButton(QPushButton):
     button_clicked = Signal()

--- a/src/osdag_gui/ui/components/custom_3dviewer.py
+++ b/src/osdag_gui/ui/components/custom_3dviewer.py
@@ -5,7 +5,7 @@ import math
 from PySide6.QtCore import QEvent, QPoint, QTimer, QTime, Qt
 from PySide6.QtWidgets import QToolTip, QApplication
 
-from osdag_gui.__config__ import CAD_BACKEND
+from ...__config__ import CAD_BACKEND
 
 from OCC.Display import backend
 backend.load_backend(CAD_BACKEND)

--- a/src/osdag_gui/ui/components/custom_buttons.py
+++ b/src/osdag_gui/ui/components/custom_buttons.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtSvgWidgets import QSvgWidget
 from PySide6.QtCore import Qt, Signal, QSize, QEvent, QRect, QPropertyAnimation, QEasingCurve
 from PySide6.QtGui import QFont, QIcon, QPainter
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ...ui.utils.custom_cursors import pointing_hand_cursor
 
 class MenuButton(QPushButton):
     """Base class for menu buttons to manage selected/unselected styles."""

--- a/src/osdag_gui/ui/components/custom_buttons.py
+++ b/src/osdag_gui/ui/components/custom_buttons.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtSvgWidgets import QSvgWidget
 from PySide6.QtCore import Qt, Signal, QSize, QEvent, QRect, QPropertyAnimation, QEasingCurve
 from PySide6.QtGui import QFont, QIcon, QPainter
-from ...ui.utils.custom_cursors import pointing_hand_cursor
+from ..utils.custom_cursors import pointing_hand_cursor
 
 class MenuButton(QPushButton):
     """Base class for menu buttons to manage selected/unselected styles."""

--- a/src/osdag_gui/ui/components/dialogs/about_osdag.py
+++ b/src/osdag_gui/ui/components/dialogs/about_osdag.py
@@ -5,9 +5,9 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon
 from PySide6.QtSvgWidgets import QSvgWidget
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .custom_titlebar import CustomTitleBar
 import osdag_gui.resources.resources_rc
-from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ...utils.custom_cursors import pointing_hand_cursor
 import markdown, os
 from importlib import resources
 

--- a/src/osdag_gui/ui/components/dialogs/about_osdag.py
+++ b/src/osdag_gui/ui/components/dialogs/about_osdag.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon
 from PySide6.QtSvgWidgets import QSvgWidget
 from .custom_titlebar import CustomTitleBar
-import osdag_gui.resources.resources_rc
+from ....resources import resources_rc
 from ...utils.custom_cursors import pointing_hand_cursor
 import markdown, os
 from importlib import resources

--- a/src/osdag_gui/ui/components/dialogs/about_osdag.py
+++ b/src/osdag_gui/ui/components/dialogs/about_osdag.py
@@ -5,9 +5,9 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon
 from PySide6.QtSvgWidgets import QSvgWidget
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 import osdag_gui.resources.resources_rc
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ....ui.utils.custom_cursors import pointing_hand_cursor
 import markdown, os
 from importlib import resources
 

--- a/src/osdag_gui/ui/components/dialogs/ask_questions.py
+++ b/src/osdag_gui/ui/components/dialogs/ask_questions.py
@@ -5,7 +5,7 @@ from PySide6.QtGui import QIcon, QCursor
 from ...utils.custom_cursors import pointing_hand_cursor
 
 from .custom_titlebar import CustomTitleBar
-import osdag_gui.resources.resources_rc
+from ....resources import resources_rc
 # from custom_titlebar import CustomTitleBar
 # import resources_rc
 

--- a/src/osdag_gui/ui/components/dialogs/ask_questions.py
+++ b/src/osdag_gui/ui/components/dialogs/ask_questions.py
@@ -2,9 +2,9 @@ import sys
 from PySide6.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QWidget
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QCursor
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ....ui.utils.custom_cursors import pointing_hand_cursor
 
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 import osdag_gui.resources.resources_rc
 # from custom_titlebar import CustomTitleBar
 # import resources_rc

--- a/src/osdag_gui/ui/components/dialogs/ask_questions.py
+++ b/src/osdag_gui/ui/components/dialogs/ask_questions.py
@@ -2,9 +2,9 @@ import sys
 from PySide6.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QWidget
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QCursor
-from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ...utils.custom_cursors import pointing_hand_cursor
 
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .custom_titlebar import CustomTitleBar
 import osdag_gui.resources.resources_rc
 # from custom_titlebar import CustomTitleBar
 # import resources_rc

--- a/src/osdag_gui/ui/components/dialogs/bounds_selector.py
+++ b/src/osdag_gui/ui/components/dialogs/bounds_selector.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QDoubleValidator
 
 from .custom_titlebar import CustomTitleBar
-import osdag_gui.resources.resources_rc
+from ....resources import resources_rc
 
 class BoundsSelectorDialog(QDialog):
     def __init__(self, title: str, default: list, parent=None):

--- a/src/osdag_gui/ui/components/dialogs/bounds_selector.py
+++ b/src/osdag_gui/ui/components/dialogs/bounds_selector.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QDoubleValidator
 
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .custom_titlebar import CustomTitleBar
 import osdag_gui.resources.resources_rc
 
 class BoundsSelectorDialog(QDialog):

--- a/src/osdag_gui/ui/components/dialogs/bounds_selector.py
+++ b/src/osdag_gui/ui/components/dialogs/bounds_selector.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QDoubleValidator
 
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 import osdag_gui.resources.resources_rc
 
 class BoundsSelectorDialog(QDialog):

--- a/src/osdag_gui/ui/components/dialogs/check_for_updates.py
+++ b/src/osdag_gui/ui/components/dialogs/check_for_updates.py
@@ -19,8 +19,8 @@ from PySide6.QtCore import QProcess, Qt
 from PySide6.QtSvgWidgets import QSvgWidget
 from PySide6.QtGui import QIcon
 
-from osdag_gui.__config__ import INSTALLATION_TYPE, VERSION
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....__config__ import INSTALLATION_TYPE, VERSION
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 
 class UpdateDialog(QDialog):
     def __init__(self, parent=None):

--- a/src/osdag_gui/ui/components/dialogs/check_for_updates.py
+++ b/src/osdag_gui/ui/components/dialogs/check_for_updates.py
@@ -20,7 +20,7 @@ from PySide6.QtSvgWidgets import QSvgWidget
 from PySide6.QtGui import QIcon
 
 from ....__config__ import INSTALLATION_TYPE, VERSION
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .custom_titlebar import CustomTitleBar
 
 class UpdateDialog(QDialog):
     def __init__(self, parent=None):

--- a/src/osdag_gui/ui/components/dialogs/custom_messagebox.py
+++ b/src/osdag_gui/ui/components/dialogs/custom_messagebox.py
@@ -3,7 +3,7 @@ from PySide6.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QPushB
 from PySide6.QtCore import Qt, QPoint
 from PySide6.QtGui import QIcon, QPixmap
 
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .custom_titlebar import CustomTitleBar
 from ....resources.resources_rc import *
 
 class MessageBoxType:

--- a/src/osdag_gui/ui/components/dialogs/custom_messagebox.py
+++ b/src/osdag_gui/ui/components/dialogs/custom_messagebox.py
@@ -3,8 +3,8 @@ from PySide6.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QPushB
 from PySide6.QtCore import Qt, QPoint
 from PySide6.QtGui import QIcon, QPixmap
 
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
-from osdag_gui.resources.resources_rc import *
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....resources.resources_rc import *
 
 class MessageBoxType:
     Information = "Information"

--- a/src/osdag_gui/ui/components/dialogs/custom_titlebar.py
+++ b/src/osdag_gui/ui/components/dialogs/custom_titlebar.py
@@ -1,7 +1,7 @@
 from PySide6.QtWidgets import QWidget, QLabel, QToolButton, QHBoxLayout, QSizePolicy, QVBoxLayout
 from PySide6.QtCore import Qt, QPoint, QEvent
 from PySide6.QtGui import QMouseEvent, QFont
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ....ui.utils.custom_cursors import pointing_hand_cursor
 
 # This return a string 'Cancel' when the close button is clicked.
 # This also returns the name of button that is clicked.

--- a/src/osdag_gui/ui/components/dialogs/custom_titlebar.py
+++ b/src/osdag_gui/ui/components/dialogs/custom_titlebar.py
@@ -1,7 +1,7 @@
 from PySide6.QtWidgets import QWidget, QLabel, QToolButton, QHBoxLayout, QSizePolicy, QVBoxLayout
 from PySide6.QtCore import Qt, QPoint, QEvent
 from PySide6.QtGui import QMouseEvent, QFont
-from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ...utils.custom_cursors import pointing_hand_cursor
 
 # This return a string 'Cancel' when the close button is clicked.
 # This also returns the name of button that is clicked.

--- a/src/osdag_gui/ui/components/dialogs/customized_popup.py
+++ b/src/osdag_gui/ui/components/dialogs/customized_popup.py
@@ -2,7 +2,7 @@ from PySide6.QtWidgets import (QPushButton, QLabel, QMessageBox, QHBoxLayout, QV
                                QListWidget, QListWidgetItem, QAbstractItemView, QApplication, QSizePolicy)
 from PySide6.QtCore import (QRect, QMetaObject, Qt)
 from PySide6.QtGui import QGuiApplication
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 
 def get_screen_dimensions():
     """

--- a/src/osdag_gui/ui/components/dialogs/customized_popup.py
+++ b/src/osdag_gui/ui/components/dialogs/customized_popup.py
@@ -2,7 +2,7 @@ from PySide6.QtWidgets import (QPushButton, QLabel, QMessageBox, QHBoxLayout, QV
                                QListWidget, QListWidgetItem, QAbstractItemView, QApplication, QSizePolicy)
 from PySide6.QtCore import (QRect, QMetaObject, Qt)
 from PySide6.QtGui import QGuiApplication
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .custom_titlebar import CustomTitleBar
 
 def get_screen_dimensions():
     """

--- a/src/osdag_gui/ui/components/dialogs/customized_report_popup.py
+++ b/src/osdag_gui/ui/components/dialogs/customized_report_popup.py
@@ -337,8 +337,8 @@ class LaTeXFilter:
 
         return '\n'.join(filtered_lines)
 
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
-from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from .custom_titlebar import CustomTitleBar
+from .custom_messagebox import CustomMessageBox, MessageBoxType
 
 class ReportCustomizationDialog(QDialog):
     """Main dialog - 200 lines max"""

--- a/src/osdag_gui/ui/components/dialogs/customized_report_popup.py
+++ b/src/osdag_gui/ui/components/dialogs/customized_report_popup.py
@@ -337,8 +337,8 @@ class LaTeXFilter:
 
         return '\n'.join(filtered_lines)
 
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
-from osdag_gui.ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
 
 class ReportCustomizationDialog(QDialog):
     """Main dialog - 200 lines max"""

--- a/src/osdag_gui/ui/components/dialogs/design_report.py
+++ b/src/osdag_gui/ui/components/dialogs/design_report.py
@@ -11,11 +11,11 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt, Signal, QCoreApplication
 from PySide6.QtGui import QIcon, QCursor
 
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
-from osdag_gui.ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
 
-from osdag_gui.ui.components.design_report.design_summary import DesignSummaryWidget
-from osdag_gui.ui.components.design_report.report_customization import CustomizationWidget
+from ....ui.components.design_report.design_summary import DesignSummaryWidget
+from ....ui.components.design_report.report_customization import CustomizationWidget
 from osdag_core.Common import get_latex_executable, get_documents_folder
 
 import os, sys

--- a/src/osdag_gui/ui/components/dialogs/design_report.py
+++ b/src/osdag_gui/ui/components/dialogs/design_report.py
@@ -11,11 +11,11 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt, Signal, QCoreApplication
 from PySide6.QtGui import QIcon, QCursor
 
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
-from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from .custom_titlebar import CustomTitleBar
+from .custom_messagebox import CustomMessageBox, MessageBoxType
 
-from ....ui.components.design_report.design_summary import DesignSummaryWidget
-from ....ui.components.design_report.report_customization import CustomizationWidget
+from ..design_report.design_summary import DesignSummaryWidget
+from ..design_report.report_customization import CustomizationWidget
 from osdag_core.Common import get_latex_executable, get_documents_folder
 
 import os, sys

--- a/src/osdag_gui/ui/components/dialogs/loading_popup.py
+++ b/src/osdag_gui/ui/components/dialogs/loading_popup.py
@@ -6,7 +6,7 @@ from PySide6.QtGui import QPainter, QColor, QPen, QIcon
 
 # Import safe_processEvents for thread-safe UI updates
 try:
-    from osdag_gui.OS_safety_protocols import safe_processEvents
+    from ....OS_safety_protocols import safe_processEvents
 except ImportError:
     # Fallback to direct call if not available
     def safe_processEvents():

--- a/src/osdag_gui/ui/components/dialogs/settings.py
+++ b/src/osdag_gui/ui/components/dialogs/settings.py
@@ -8,8 +8,8 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QFont
 
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
-from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from .custom_titlebar import CustomTitleBar
+from .custom_messagebox import CustomMessageBox, MessageBoxType
 import osdag_gui.resources.resources_rc
 
 

--- a/src/osdag_gui/ui/components/dialogs/settings.py
+++ b/src/osdag_gui/ui/components/dialogs/settings.py
@@ -10,7 +10,7 @@ from PySide6.QtGui import QIcon, QFont
 
 from .custom_titlebar import CustomTitleBar
 from .custom_messagebox import CustomMessageBox, MessageBoxType
-import osdag_gui.resources.resources_rc
+from ....resources import resources_rc
 
 
 def _section_header(text: str) -> QLabel:

--- a/src/osdag_gui/ui/components/dialogs/settings.py
+++ b/src/osdag_gui/ui/components/dialogs/settings.py
@@ -8,8 +8,8 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QFont
 
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
-from osdag_gui.ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
 import osdag_gui.resources.resources_rc
 
 

--- a/src/osdag_gui/ui/components/dialogs/spacing_dialog.py
+++ b/src/osdag_gui/ui/components/dialogs/spacing_dialog.py
@@ -1,4 +1,4 @@
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 from PySide6.QtWidgets import (

--- a/src/osdag_gui/ui/components/dialogs/spacing_dialog.py
+++ b/src/osdag_gui/ui/components/dialogs/spacing_dialog.py
@@ -1,4 +1,4 @@
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 from PySide6.QtWidgets import (

--- a/src/osdag_gui/ui/components/dialogs/video_tutorials.py
+++ b/src/osdag_gui/ui/components/dialogs/video_tutorials.py
@@ -5,7 +5,7 @@ from PySide6.QtGui import QIcon, QCursor
 from ...utils.custom_cursors import pointing_hand_cursor
 
 from .custom_titlebar import CustomTitleBar
-import osdag_gui.resources.resources_rc
+from ....resources import resources_rc
 # from custom_titlebar import CustomTitleBar
 # import resources_rc
 

--- a/src/osdag_gui/ui/components/dialogs/video_tutorials.py
+++ b/src/osdag_gui/ui/components/dialogs/video_tutorials.py
@@ -2,9 +2,9 @@ import sys
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QWidget
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QCursor
-from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ...utils.custom_cursors import pointing_hand_cursor
 
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .custom_titlebar import CustomTitleBar
 import osdag_gui.resources.resources_rc
 # from custom_titlebar import CustomTitleBar
 # import resources_rc

--- a/src/osdag_gui/ui/components/dialogs/video_tutorials.py
+++ b/src/osdag_gui/ui/components/dialogs/video_tutorials.py
@@ -2,9 +2,9 @@ import sys
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QWidget
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QCursor
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ....ui.utils.custom_cursors import pointing_hand_cursor
 
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 import osdag_gui.resources.resources_rc
 # from custom_titlebar import CustomTitleBar
 # import resources_rc

--- a/src/osdag_gui/ui/components/docks/input_dock.py
+++ b/src/osdag_gui/ui/components/docks/input_dock.py
@@ -16,7 +16,7 @@ from ....OS_safety_protocols import get_cleanup_coordinator
 
 from ..additional_inputs_button import AdditionalInputsButton
 from ..custom_buttons import DockCustomButton
-import osdag_gui.resources.resources_rc
+from ....resources import resources_rc
 from ..dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
 from ..dialogs.customized_popup import CustomValueSelectPopup
 from ..dialogs.custom_titlebar import CustomTitleBar

--- a/src/osdag_gui/ui/components/docks/input_dock.py
+++ b/src/osdag_gui/ui/components/docks/input_dock.py
@@ -11,16 +11,16 @@ from PySide6.QtWidgets import QMessageBox, QDialog, QGridLayout, QListView
 from PySide6.QtCore import Qt, QRegularExpression, QCoreApplication, QEvent, QTimer, QPoint
 from PySide6.QtGui import (QPixmap, QBrush, QColor, QDoubleValidator,
         QRegularExpressionValidator, QIntValidator, QIcon, QCursor)
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
-from osdag_gui.OS_safety_protocols import get_cleanup_coordinator
+from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ....OS_safety_protocols import get_cleanup_coordinator
 
-from osdag_gui.ui.components.additional_inputs_button import AdditionalInputsButton
-from osdag_gui.ui.components.custom_buttons import DockCustomButton
+from ....ui.components.additional_inputs_button import AdditionalInputsButton
+from ....ui.components.custom_buttons import DockCustomButton
 import osdag_gui.resources.resources_rc
-from osdag_gui.ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
-from osdag_gui.ui.components.dialogs.customized_popup import CustomValueSelectPopup
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
-from osdag_gui.ui.components.dialogs.bounds_selector import BoundsSelectorDialog
+from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from ....ui.components.dialogs.customized_popup import CustomValueSelectPopup
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.bounds_selector import BoundsSelectorDialog
 
 from osdag_core.Common import *
 
@@ -1093,8 +1093,8 @@ class InputDock(QWidget):
     
 #----------------Standalone-Test-Code--------------------------------
 from osdag_core.design_type.connection.fin_plate_connection import FinPlateConnection
-from osdag_gui.OS_safety_protocols import setup_environment
-from osdag_gui.OS_safety_protocols import get_cleanup_coordinator
+from ....OS_safety_protocols import setup_environment
+from ....OS_safety_protocols import get_cleanup_coordinator
 
 class MyMainWindow(QMainWindow):
     def __init__(self):

--- a/src/osdag_gui/ui/components/docks/input_dock.py
+++ b/src/osdag_gui/ui/components/docks/input_dock.py
@@ -11,16 +11,16 @@ from PySide6.QtWidgets import QMessageBox, QDialog, QGridLayout, QListView
 from PySide6.QtCore import Qt, QRegularExpression, QCoreApplication, QEvent, QTimer, QPoint
 from PySide6.QtGui import (QPixmap, QBrush, QColor, QDoubleValidator,
         QRegularExpressionValidator, QIntValidator, QIcon, QCursor)
-from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ...utils.custom_cursors import pointing_hand_cursor
 from ....OS_safety_protocols import get_cleanup_coordinator
 
-from ....ui.components.additional_inputs_button import AdditionalInputsButton
-from ....ui.components.custom_buttons import DockCustomButton
+from ..additional_inputs_button import AdditionalInputsButton
+from ..custom_buttons import DockCustomButton
 import osdag_gui.resources.resources_rc
-from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
-from ....ui.components.dialogs.customized_popup import CustomValueSelectPopup
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
-from ....ui.components.dialogs.bounds_selector import BoundsSelectorDialog
+from ..dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from ..dialogs.customized_popup import CustomValueSelectPopup
+from ..dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.bounds_selector import BoundsSelectorDialog
 
 from osdag_core.Common import *
 

--- a/src/osdag_gui/ui/components/docks/output_dock.py
+++ b/src/osdag_gui/ui/components/docks/output_dock.py
@@ -11,14 +11,14 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, QPropertyAnimation, QEasingCurve
 from PySide6.QtGui import QCursor
-from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ...utils.custom_cursors import pointing_hand_cursor
 
 from osdag_core.texlive.Design_wrapper import init_display as init_display_off_screen
 
-from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
-from ....ui.components.custom_buttons import DockCustomButton
-from ....ui.components.dialogs.design_report import DesignReportDialog
-from ....ui.components.dialogs.spacing_dialog import SpacingDialog
+from ..dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from ..custom_buttons import DockCustomButton
+from ..dialogs.design_report import DesignReportDialog
+from ..dialogs.spacing_dialog import SpacingDialog
 
 from ....data.database.database_config import *
 from osdag_core.Common import *
@@ -26,38 +26,38 @@ from osdag_core.export_ifc.cad_extraction import extract_cad_items, obj_to_dict,
 import osdag_gui.resources.resources_rc
 
 # Spacing Detail
-from ....ui.components.output_details.b2b_cover_plate_welded import B2BCoverPlateWeldedDetails
-from ....ui.components.output_details.b2b_cover_plate import B2BCoverPlateDetails
-from ....ui.components.output_details.b2c_end_plate import B2CEndPlateDetails
-from ....ui.components.output_details.b2b_end_plate_sketch import B2BEndPlateSketch
-from ....ui.components.output_details.base_plate import BasePlateDetails
-from ....ui.components.output_details.base_plate_hollow import BasePlateHollowDetails
-from ....ui.components.output_details.c2c_end_plate import C2CEndPlateDetails
-from ....ui.components.output_details.fin_plate_capacity import (
+from ..output_details.b2b_cover_plate_welded import B2BCoverPlateWeldedDetails
+from ..output_details.b2b_cover_plate import B2BCoverPlateDetails
+from ..output_details.b2c_end_plate import B2CEndPlateDetails
+from ..output_details.b2b_end_plate_sketch import B2BEndPlateSketch
+from ..output_details.base_plate import BasePlateDetails
+from ..output_details.base_plate_hollow import BasePlateHollowDetails
+from ..output_details.c2c_end_plate import C2CEndPlateDetails
+from ..output_details.fin_plate_capacity import (
     FinPlateCapacityDetails, 
     SectionCapacityDetails,
 ) 
-from ....ui.components.output_details.end_plate_capacity import (
+from ..output_details.end_plate_capacity import (
     EndPlateCapacityDetails,      
     EndPlateSectionDetails,       
 )
-from ....ui.components.output_details.seated_angle_capacity import (
+from ..output_details.seated_angle_capacity import (
     SeatedAngleCapacityDetails,
     SeatedAngleSectionDetails,
 )
-from ....ui.components.output_details.end_plate import EndPlateDetails
-from ....ui.components.output_details.bolt_pattern import BoltPatternGenerator
-from ....ui.components.output_details.seated_angle_spacing import SeatedAngleDetails
-from ....ui.components.output_details.cleat_angle import (
+from ..output_details.end_plate import EndPlateDetails
+from ..output_details.bolt_pattern import BoltPatternGenerator
+from ..output_details.seated_angle_spacing import SeatedAngleDetails
+from ..output_details.cleat_angle import (
     CleatAngleDetails,
     CleatAngleCapacityDetails,
     CleatAngleSectionDetails,
 )
-from ....ui.components.output_details.tension_bolted_spacing import TensionBoltedDetails
-from ....ui.components.output_details.plate_fracture_digram.beam_web_plate import BeamWebFractureDialog
-from ....ui.components.output_details.plate_fracture_digram.beam_flange_plate import BeamFlangeFractureDialog
-from ....ui.components.output_details.plate_fracture_digram.column_web_plate import ColWebFractureDialog
-from ....ui.components.output_details.plate_fracture_digram.column_flange_plate import ColFlangeFractureDialog
+from ..output_details.tension_bolted_spacing import TensionBoltedDetails
+from ..output_details.plate_fracture_digram.beam_web_plate import BeamWebFractureDialog
+from ..output_details.plate_fracture_digram.beam_flange_plate import BeamFlangeFractureDialog
+from ..output_details.plate_fracture_digram.column_web_plate import ColWebFractureDialog
+from ..output_details.plate_fracture_digram.column_flange_plate import ColFlangeFractureDialog
 
 from ....__config__ import CAD_BACKEND
 from ....OS_safety_protocols import get_cleanup_coordinator

--- a/src/osdag_gui/ui/components/docks/output_dock.py
+++ b/src/osdag_gui/ui/components/docks/output_dock.py
@@ -23,7 +23,7 @@ from ..dialogs.spacing_dialog import SpacingDialog
 from ....data.database.database_config import *
 from osdag_core.Common import *
 from osdag_core.export_ifc.cad_extraction import extract_cad_items, obj_to_dict, extract_metadata
-import osdag_gui.resources.resources_rc
+from ....resources import resources_rc
 
 # Spacing Detail
 from ..output_details.b2b_cover_plate_welded import B2BCoverPlateWeldedDetails

--- a/src/osdag_gui/ui/components/docks/output_dock.py
+++ b/src/osdag_gui/ui/components/docks/output_dock.py
@@ -11,56 +11,56 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, QPropertyAnimation, QEasingCurve
 from PySide6.QtGui import QCursor
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ....ui.utils.custom_cursors import pointing_hand_cursor
 
 from osdag_core.texlive.Design_wrapper import init_display as init_display_off_screen
 
-from osdag_gui.ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
-from osdag_gui.ui.components.custom_buttons import DockCustomButton
-from osdag_gui.ui.components.dialogs.design_report import DesignReportDialog
-from osdag_gui.ui.components.dialogs.spacing_dialog import SpacingDialog
+from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from ....ui.components.custom_buttons import DockCustomButton
+from ....ui.components.dialogs.design_report import DesignReportDialog
+from ....ui.components.dialogs.spacing_dialog import SpacingDialog
 
-from osdag_gui.data.database.database_config import *
+from ....data.database.database_config import *
 from osdag_core.Common import *
 from osdag_core.export_ifc.cad_extraction import extract_cad_items, obj_to_dict, extract_metadata
 import osdag_gui.resources.resources_rc
 
 # Spacing Detail
-from osdag_gui.ui.components.output_details.b2b_cover_plate_welded import B2BCoverPlateWeldedDetails
-from osdag_gui.ui.components.output_details.b2b_cover_plate import B2BCoverPlateDetails
-from osdag_gui.ui.components.output_details.b2c_end_plate import B2CEndPlateDetails
-from osdag_gui.ui.components.output_details.b2b_end_plate_sketch import B2BEndPlateSketch
-from osdag_gui.ui.components.output_details.base_plate import BasePlateDetails
-from osdag_gui.ui.components.output_details.base_plate_hollow import BasePlateHollowDetails
-from osdag_gui.ui.components.output_details.c2c_end_plate import C2CEndPlateDetails
-from osdag_gui.ui.components.output_details.fin_plate_capacity import (
+from ....ui.components.output_details.b2b_cover_plate_welded import B2BCoverPlateWeldedDetails
+from ....ui.components.output_details.b2b_cover_plate import B2BCoverPlateDetails
+from ....ui.components.output_details.b2c_end_plate import B2CEndPlateDetails
+from ....ui.components.output_details.b2b_end_plate_sketch import B2BEndPlateSketch
+from ....ui.components.output_details.base_plate import BasePlateDetails
+from ....ui.components.output_details.base_plate_hollow import BasePlateHollowDetails
+from ....ui.components.output_details.c2c_end_plate import C2CEndPlateDetails
+from ....ui.components.output_details.fin_plate_capacity import (
     FinPlateCapacityDetails, 
     SectionCapacityDetails,
 ) 
-from osdag_gui.ui.components.output_details.end_plate_capacity import (
+from ....ui.components.output_details.end_plate_capacity import (
     EndPlateCapacityDetails,      
     EndPlateSectionDetails,       
 )
-from osdag_gui.ui.components.output_details.seated_angle_capacity import (
+from ....ui.components.output_details.seated_angle_capacity import (
     SeatedAngleCapacityDetails,
     SeatedAngleSectionDetails,
 )
-from osdag_gui.ui.components.output_details.end_plate import EndPlateDetails
-from osdag_gui.ui.components.output_details.bolt_pattern import BoltPatternGenerator
-from osdag_gui.ui.components.output_details.seated_angle_spacing import SeatedAngleDetails
-from osdag_gui.ui.components.output_details.cleat_angle import (
+from ....ui.components.output_details.end_plate import EndPlateDetails
+from ....ui.components.output_details.bolt_pattern import BoltPatternGenerator
+from ....ui.components.output_details.seated_angle_spacing import SeatedAngleDetails
+from ....ui.components.output_details.cleat_angle import (
     CleatAngleDetails,
     CleatAngleCapacityDetails,
     CleatAngleSectionDetails,
 )
-from osdag_gui.ui.components.output_details.tension_bolted_spacing import TensionBoltedDetails
-from osdag_gui.ui.components.output_details.plate_fracture_digram.beam_web_plate import BeamWebFractureDialog
-from osdag_gui.ui.components.output_details.plate_fracture_digram.beam_flange_plate import BeamFlangeFractureDialog
-from osdag_gui.ui.components.output_details.plate_fracture_digram.column_web_plate import ColWebFractureDialog
-from osdag_gui.ui.components.output_details.plate_fracture_digram.column_flange_plate import ColFlangeFractureDialog
+from ....ui.components.output_details.tension_bolted_spacing import TensionBoltedDetails
+from ....ui.components.output_details.plate_fracture_digram.beam_web_plate import BeamWebFractureDialog
+from ....ui.components.output_details.plate_fracture_digram.beam_flange_plate import BeamFlangeFractureDialog
+from ....ui.components.output_details.plate_fracture_digram.column_web_plate import ColWebFractureDialog
+from ....ui.components.output_details.plate_fracture_digram.column_flange_plate import ColFlangeFractureDialog
 
-from osdag_gui.__config__ import CAD_BACKEND
-from osdag_gui.OS_safety_protocols import get_cleanup_coordinator
+from ....__config__ import CAD_BACKEND
+from ....OS_safety_protocols import get_cleanup_coordinator
 
 class DummyCADWidget:
     """

--- a/src/osdag_gui/ui/components/floating_nav_bar.py
+++ b/src/osdag_gui/ui/components/floating_nav_bar.py
@@ -3,8 +3,8 @@ Floating navigation bar for Osdag GUI.
 Provides quick access to modules and emits tab open signals.
 """
 import osdag_gui.resources.resources_rc
-from osdag_gui.data.ui_data import Data
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ...data.ui_data import Data
+from ...ui.utils.custom_cursors import pointing_hand_cursor
 
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QPushButton, QToolTip, QApplication, QSizePolicy

--- a/src/osdag_gui/ui/components/floating_nav_bar.py
+++ b/src/osdag_gui/ui/components/floating_nav_bar.py
@@ -4,7 +4,7 @@ Provides quick access to modules and emits tab open signals.
 """
 import osdag_gui.resources.resources_rc
 from ...data.ui_data import Data
-from ...ui.utils.custom_cursors import pointing_hand_cursor
+from ..utils.custom_cursors import pointing_hand_cursor
 
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QPushButton, QToolTip, QApplication, QSizePolicy

--- a/src/osdag_gui/ui/components/floating_nav_bar.py
+++ b/src/osdag_gui/ui/components/floating_nav_bar.py
@@ -2,7 +2,7 @@
 Floating navigation bar for Osdag GUI.
 Provides quick access to modules and emits tab open signals.
 """
-import osdag_gui.resources.resources_rc
+from ...resources import resources_rc
 from ...data.ui_data import Data
 from ..utils.custom_cursors import pointing_hand_cursor
 

--- a/src/osdag_gui/ui/components/home/home_widget.py
+++ b/src/osdag_gui/ui/components/home/home_widget.py
@@ -11,12 +11,12 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, QSize, Signal, QPropertyAnimation, QEasingCurve, QThread
 from PySide6.QtGui import QIcon, QKeySequence, QColor, QFont, QShortcut, QFontMetrics, QCursor
-from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ...utils.custom_cursors import pointing_hand_cursor
 from PySide6.QtSvgWidgets import QSvgWidget
 
 import osdag_gui.resources.resources_rc
-from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
-from ....ui.components.home.search_overlay import SearchOverlay
+from ..dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from .search_overlay import SearchOverlay
 from ....data.database.database_config import *
 from ....data.ui_data import Data
 

--- a/src/osdag_gui/ui/components/home/home_widget.py
+++ b/src/osdag_gui/ui/components/home/home_widget.py
@@ -14,7 +14,7 @@ from PySide6.QtGui import QIcon, QKeySequence, QColor, QFont, QShortcut, QFontMe
 from ...utils.custom_cursors import pointing_hand_cursor
 from PySide6.QtSvgWidgets import QSvgWidget
 
-import osdag_gui.resources.resources_rc
+from ....resources import resources_rc
 from ..dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
 from .search_overlay import SearchOverlay
 from ....data.database.database_config import *

--- a/src/osdag_gui/ui/components/home/home_widget.py
+++ b/src/osdag_gui/ui/components/home/home_widget.py
@@ -11,14 +11,14 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, QSize, Signal, QPropertyAnimation, QEasingCurve, QThread
 from PySide6.QtGui import QIcon, QKeySequence, QColor, QFont, QShortcut, QFontMetrics, QCursor
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ....ui.utils.custom_cursors import pointing_hand_cursor
 from PySide6.QtSvgWidgets import QSvgWidget
 
 import osdag_gui.resources.resources_rc
-from osdag_gui.ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
-from osdag_gui.ui.components.home.search_overlay import SearchOverlay
-from osdag_gui.data.database.database_config import *
-from osdag_gui.data.ui_data import Data
+from ....ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from ....ui.components.home.search_overlay import SearchOverlay
+from ....data.database.database_config import *
+from ....data.ui_data import Data
 
 # --- SVG Widget with Theme Support ---
 class ThemedSvgWidget(QSvgWidget):

--- a/src/osdag_gui/ui/components/home/navbar.py
+++ b/src/osdag_gui/ui/components/home/navbar.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtGui import QFont, QCursor, QIcon, QPainter, QColor
 from PySide6.QtCore import Qt, QSize, QEvent, Signal
-from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ...utils.custom_cursors import pointing_hand_cursor
 from PySide6.QtSvgWidgets import QSvgWidget
 
 from ....__config__ import VERSION

--- a/src/osdag_gui/ui/components/home/navbar.py
+++ b/src/osdag_gui/ui/components/home/navbar.py
@@ -12,7 +12,7 @@ from ...utils.custom_cursors import pointing_hand_cursor
 from PySide6.QtSvgWidgets import QSvgWidget
 
 from ....__config__ import VERSION
-import osdag_gui.resources.resources_rc
+from ....resources import resources_rc
 
 class CustomButton(QPushButton):
     def __init__(self, text, icon_path_default, icon_path_clicked, icon_dark, under_dev=False, group=None, parent=None):

--- a/src/osdag_gui/ui/components/home/navbar.py
+++ b/src/osdag_gui/ui/components/home/navbar.py
@@ -8,10 +8,10 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtGui import QFont, QCursor, QIcon, QPainter, QColor
 from PySide6.QtCore import Qt, QSize, QEvent, Signal
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ....ui.utils.custom_cursors import pointing_hand_cursor
 from PySide6.QtSvgWidgets import QSvgWidget
 
-from osdag_gui.__config__ import VERSION
+from ....__config__ import VERSION
 import osdag_gui.resources.resources_rc
 
 class CustomButton(QPushButton):

--- a/src/osdag_gui/ui/components/home/search_overlay.py
+++ b/src/osdag_gui/ui/components/home/search_overlay.py
@@ -8,9 +8,9 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, Signal, QPoint, QPropertyAnimation, QEasingCurve, QTimer, QEvent, QSize
 from PySide6.QtGui import QCursor, QPainterPath, QRegion, QIcon
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
-from osdag_gui.data.database.database_config import *
-from osdag_gui.data.ui_data import Data
+from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ....data.database.database_config import *
+from ....data.ui_data import Data
 
 class SearchResultItem(QFrame):
     """Individual search result item with expandable action buttons"""

--- a/src/osdag_gui/ui/components/home/search_overlay.py
+++ b/src/osdag_gui/ui/components/home/search_overlay.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, Signal, QPoint, QPropertyAnimation, QEasingCurve, QTimer, QEvent, QSize
 from PySide6.QtGui import QCursor, QPainterPath, QRegion, QIcon
-from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ...utils.custom_cursors import pointing_hand_cursor
 from ....data.database.database_config import *
 from ....data.ui_data import Data
 

--- a/src/osdag_gui/ui/components/home/top_right_buttons.py
+++ b/src/osdag_gui/ui/components/home/top_right_buttons.py
@@ -7,12 +7,12 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, QSize, QPoint, QPropertyAnimation, QEasingCurve, QTimer, Signal
 from PySide6.QtGui import QIcon, QAction
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
-from osdag_gui.ui.components.dialogs.video_tutorials import TutorialsDialog
-from osdag_gui.ui.components.dialogs.ask_questions import AskQuestions
-from osdag_gui.ui.components.dialogs.about_osdag import AboutOsdagDialog
-from osdag_gui.ui.components.dialogs.check_for_updates import UpdateDialog
-from osdag_gui.common_functions import design_examples
+from ....ui.utils.custom_cursors import pointing_hand_cursor
+from ....ui.components.dialogs.video_tutorials import TutorialsDialog
+from ....ui.components.dialogs.ask_questions import AskQuestions
+from ....ui.components.dialogs.about_osdag import AboutOsdagDialog
+from ....ui.components.dialogs.check_for_updates import UpdateDialog
+from ....common_functions import design_examples
 
 class TopButton(QPushButton):
     """

--- a/src/osdag_gui/ui/components/home/top_right_buttons.py
+++ b/src/osdag_gui/ui/components/home/top_right_buttons.py
@@ -7,11 +7,11 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, QSize, QPoint, QPropertyAnimation, QEasingCurve, QTimer, Signal
 from PySide6.QtGui import QIcon, QAction
-from ....ui.utils.custom_cursors import pointing_hand_cursor
-from ....ui.components.dialogs.video_tutorials import TutorialsDialog
-from ....ui.components.dialogs.ask_questions import AskQuestions
-from ....ui.components.dialogs.about_osdag import AboutOsdagDialog
-from ....ui.components.dialogs.check_for_updates import UpdateDialog
+from ...utils.custom_cursors import pointing_hand_cursor
+from ..dialogs.video_tutorials import TutorialsDialog
+from ..dialogs.ask_questions import AskQuestions
+from ..dialogs.about_osdag import AboutOsdagDialog
+from ..dialogs.check_for_updates import UpdateDialog
 from ....common_functions import design_examples
 
 class TopButton(QPushButton):

--- a/src/osdag_gui/ui/components/output_details/b2b_cover_plate.py
+++ b/src/osdag_gui/ui/components/output_details/b2b_cover_plate.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class B2BCoverPlateDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/b2b_cover_plate.py
+++ b/src/osdag_gui/ui/components/output_details/b2b_cover_plate.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class B2BCoverPlateDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/b2b_cover_plate_welded.py
+++ b/src/osdag_gui/ui/components/output_details/b2b_cover_plate_welded.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class B2BCoverPlateWeldedDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/b2b_cover_plate_welded.py
+++ b/src/osdag_gui/ui/components/output_details/b2b_cover_plate_welded.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class B2BCoverPlateWeldedDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/b2b_end_plate_sketch.py
+++ b/src/osdag_gui/ui/components/output_details/b2b_end_plate_sketch.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 

--- a/src/osdag_gui/ui/components/output_details/b2b_end_plate_sketch.py
+++ b/src/osdag_gui/ui/components/output_details/b2b_end_plate_sketch.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 

--- a/src/osdag_gui/ui/components/output_details/b2c_end_plate.py
+++ b/src/osdag_gui/ui/components/output_details/b2c_end_plate.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class B2CEndPlateDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/b2c_end_plate.py
+++ b/src/osdag_gui/ui/components/output_details/b2c_end_plate.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class B2CEndPlateDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/base_plate.py
+++ b/src/osdag_gui/ui/components/output_details/base_plate.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class BasePlateDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/base_plate.py
+++ b/src/osdag_gui/ui/components/output_details/base_plate.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class BasePlateDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/base_plate_hollow.py
+++ b/src/osdag_gui/ui/components/output_details/base_plate_hollow.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class BasePlateHollowDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/base_plate_hollow.py
+++ b/src/osdag_gui/ui/components/output_details/base_plate_hollow.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class BasePlateHollowDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/bolt_pattern.py
+++ b/src/osdag_gui/ui/components/output_details/bolt_pattern.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class BoltPatternGenerator(QDialog):

--- a/src/osdag_gui/ui/components/output_details/bolt_pattern.py
+++ b/src/osdag_gui/ui/components/output_details/bolt_pattern.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class BoltPatternGenerator(QDialog):

--- a/src/osdag_gui/ui/components/output_details/c2c_end_plate.py
+++ b/src/osdag_gui/ui/components/output_details/c2c_end_plate.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class C2CEndPlateDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/c2c_end_plate.py
+++ b/src/osdag_gui/ui/components/output_details/c2c_end_plate.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Qt, QRectF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class C2CEndPlateDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/cleat_angle.py
+++ b/src/osdag_gui/ui/components/output_details/cleat_angle.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QPainter, QPen, QFont
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 

--- a/src/osdag_gui/ui/components/output_details/cleat_angle.py
+++ b/src/osdag_gui/ui/components/output_details/cleat_angle.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QPainter, QPen, QFont
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 

--- a/src/osdag_gui/ui/components/output_details/end_plate.py
+++ b/src/osdag_gui/ui/components/output_details/end_plate.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QPainter, QPen, QFont
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class EndPlateDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/end_plate.py
+++ b/src/osdag_gui/ui/components/output_details/end_plate.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QPainter, QPen, QFont
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class EndPlateDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/end_plate_capacity.py
+++ b/src/osdag_gui/ui/components/output_details/end_plate_capacity.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, QPointF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor, QPolygonF, QBrush
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 

--- a/src/osdag_gui/ui/components/output_details/end_plate_capacity.py
+++ b/src/osdag_gui/ui/components/output_details/end_plate_capacity.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, QPointF
 from PySide6.QtGui import QPainter, QPen, QFont, QColor, QPolygonF, QBrush
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 

--- a/src/osdag_gui/ui/components/output_details/fin_plate_capacity.py
+++ b/src/osdag_gui/ui/components/output_details/fin_plate_capacity.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import (QApplication, QDialog, QWidget, QVBoxLayout,
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QPainter, QPen, QFont, QColor, QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 

--- a/src/osdag_gui/ui/components/output_details/fin_plate_capacity.py
+++ b/src/osdag_gui/ui/components/output_details/fin_plate_capacity.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import (QApplication, QDialog, QWidget, QVBoxLayout,
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QPainter, QPen, QFont, QColor, QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 

--- a/src/osdag_gui/ui/components/output_details/plate_fracture_digram/beam_flange_plate.py
+++ b/src/osdag_gui/ui/components/output_details/plate_fracture_digram/beam_flange_plate.py
@@ -1,4 +1,4 @@
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 from PySide6.QtWidgets import (

--- a/src/osdag_gui/ui/components/output_details/plate_fracture_digram/beam_flange_plate.py
+++ b/src/osdag_gui/ui/components/output_details/plate_fracture_digram/beam_flange_plate.py
@@ -1,4 +1,4 @@
-from .....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ...dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 from PySide6.QtWidgets import (

--- a/src/osdag_gui/ui/components/output_details/plate_fracture_digram/beam_web_plate.py
+++ b/src/osdag_gui/ui/components/output_details/plate_fracture_digram/beam_web_plate.py
@@ -1,4 +1,4 @@
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 from PySide6.QtWidgets import (

--- a/src/osdag_gui/ui/components/output_details/plate_fracture_digram/beam_web_plate.py
+++ b/src/osdag_gui/ui/components/output_details/plate_fracture_digram/beam_web_plate.py
@@ -1,4 +1,4 @@
-from .....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ...dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 from PySide6.QtWidgets import (

--- a/src/osdag_gui/ui/components/output_details/plate_fracture_digram/column_flange_plate.py
+++ b/src/osdag_gui/ui/components/output_details/plate_fracture_digram/column_flange_plate.py
@@ -1,4 +1,4 @@
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 from PySide6.QtWidgets import (

--- a/src/osdag_gui/ui/components/output_details/plate_fracture_digram/column_flange_plate.py
+++ b/src/osdag_gui/ui/components/output_details/plate_fracture_digram/column_flange_plate.py
@@ -1,4 +1,4 @@
-from .....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ...dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 from PySide6.QtWidgets import (

--- a/src/osdag_gui/ui/components/output_details/plate_fracture_digram/column_web_plate.py
+++ b/src/osdag_gui/ui/components/output_details/plate_fracture_digram/column_web_plate.py
@@ -1,4 +1,4 @@
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from .....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 from PySide6.QtWidgets import (

--- a/src/osdag_gui/ui/components/output_details/plate_fracture_digram/column_web_plate.py
+++ b/src/osdag_gui/ui/components/output_details/plate_fracture_digram/column_web_plate.py
@@ -1,4 +1,4 @@
-from .....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ...dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 from PySide6.QtWidgets import (

--- a/src/osdag_gui/ui/components/output_details/seated_angle_capacity.py
+++ b/src/osdag_gui/ui/components/output_details/seated_angle_capacity.py
@@ -9,7 +9,7 @@ from PySide6.QtGui import (
     QPainter, QPen, QFont, QColor, QPolygonF, QBrush
 )
 
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 

--- a/src/osdag_gui/ui/components/output_details/seated_angle_capacity.py
+++ b/src/osdag_gui/ui/components/output_details/seated_angle_capacity.py
@@ -9,7 +9,7 @@ from PySide6.QtGui import (
     QPainter, QPen, QFont, QColor, QPolygonF, QBrush
 )
 
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 

--- a/src/osdag_gui/ui/components/output_details/seated_angle_spacing.py
+++ b/src/osdag_gui/ui/components/output_details/seated_angle_spacing.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QPainter, QPen, QFont
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class SeatedAngleDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/seated_angle_spacing.py
+++ b/src/osdag_gui/ui/components/output_details/seated_angle_spacing.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QPainter, QPen, QFont
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class SeatedAngleDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/tension_bolted_spacing.py
+++ b/src/osdag_gui/ui/components/output_details/tension_bolted_spacing.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QPainter, QPen, QFont
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ..dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class TensionBoltedDetails(QDialog):

--- a/src/osdag_gui/ui/components/output_details/tension_bolted_spacing.py
+++ b/src/osdag_gui/ui/components/output_details/tension_bolted_spacing.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QPainter, QPen, QFont
 from PySide6.QtGui import QPolygonF, QBrush
 from PySide6.QtCore import QPointF
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ....ui.components.dialogs.custom_titlebar import CustomTitleBar
 from osdag_core.Common import *
 
 class TensionBoltedDetails(QDialog):

--- a/src/osdag_gui/ui/components/svg_card.py
+++ b/src/osdag_gui/ui/components/svg_card.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtSvgWidgets import QSvgWidget
 from PySide6.QtCore import Qt, Signal, QEvent, QPropertyAnimation, QEasingCurve
 from PySide6.QtGui import QPixmap, QCursor
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ...ui.utils.custom_cursors import pointing_hand_cursor
 
 class ClickableLabel(QLabel):
     clicked = Signal(str)

--- a/src/osdag_gui/ui/components/svg_card.py
+++ b/src/osdag_gui/ui/components/svg_card.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtSvgWidgets import QSvgWidget
 from PySide6.QtCore import Qt, Signal, QEvent, QPropertyAnimation, QEasingCurve
 from PySide6.QtGui import QPixmap, QCursor
-from ...ui.utils.custom_cursors import pointing_hand_cursor
+from ..utils.custom_cursors import pointing_hand_cursor
 
 class ClickableLabel(QLabel):
     clicked = Signal(str)

--- a/src/osdag_gui/ui/windows/additional_inputs.py
+++ b/src/osdag_gui/ui/windows/additional_inputs.py
@@ -10,8 +10,8 @@ from osdag_core.Common import *
 from osdag_core.utils.common.Section_Properties_Calculator import *
 from osdag_core.utils.common.component import *
 from osdag_core.utils.common.other_standards import *
-from ...ui.components.dialogs.custom_titlebar import CustomTitleBar
-from ...ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from ..components.dialogs.custom_titlebar import CustomTitleBar
+from ..components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
 
 import sqlite3
 

--- a/src/osdag_gui/ui/windows/additional_inputs.py
+++ b/src/osdag_gui/ui/windows/additional_inputs.py
@@ -10,8 +10,8 @@ from osdag_core.Common import *
 from osdag_core.utils.common.Section_Properties_Calculator import *
 from osdag_core.utils.common.component import *
 from osdag_core.utils.common.other_standards import *
-from osdag_gui.ui.components.dialogs.custom_titlebar import CustomTitleBar
-from osdag_gui.ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from ...ui.components.dialogs.custom_titlebar import CustomTitleBar
+from ...ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
 
 import sqlite3
 

--- a/src/osdag_gui/ui/windows/home_window.py
+++ b/src/osdag_gui/ui/windows/home_window.py
@@ -2,7 +2,7 @@
 Home window for Osdag GUI.
 Displays navigation, SVG cards, and home widgets.
 """
-import osdag_gui.resources.resources_rc
+from ...resources import resources_rc
 
 from PySide6.QtCore import QRectF, Signal, Slot
 

--- a/src/osdag_gui/ui/windows/home_window.py
+++ b/src/osdag_gui/ui/windows/home_window.py
@@ -15,13 +15,13 @@ from PySide6.QtCore import Qt, Signal, QSize, QPropertyAnimation, QEasingCurve, 
 from PySide6.QtGui import QFont, QIcon, QPaintEvent, QPainter, QColor, QPixmap
 from PySide6.QtSvg import QSvgRenderer
 
-from osdag_gui.data.ui_data import Data
-from osdag_gui.ui.components.svg_card import SvgCardContainer
-from osdag_gui.ui.components.home.navbar import VerticalMenuBar
-from osdag_gui.ui.components.custom_buttons import MenuButton
-from osdag_gui.ui.components.home.top_right_buttons import TopButton, DropDownButton
-from osdag_gui.ui.components.home.home_widget import HomeWidget
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ...data.ui_data import Data
+from ..components.svg_card import SvgCardContainer
+from ..components.home.navbar import VerticalMenuBar
+from ..components.custom_buttons import MenuButton
+from ..components.home.top_right_buttons import TopButton, DropDownButton
+from ..components.home.home_widget import HomeWidget
+from ..utils.custom_cursors import pointing_hand_cursor
 
 # --- Internet Connectivity Indicator Button ---
 class InternetConnectionIndicator(TopButton):

--- a/src/osdag_gui/ui/windows/launch_screen.py
+++ b/src/osdag_gui/ui/windows/launch_screen.py
@@ -2,7 +2,7 @@
 Launch screen UI for Osdag GUI.
 Displays splash screen with animation and logos.
 """
-import osdag_gui.resources.resources_rc
+from ...resources import resources_rc
 
 from PySide6.QtCore import (QCoreApplication, QMetaObject, QEasingCurve,
                             QRect, QTimer, Qt, QPropertyAnimation)

--- a/src/osdag_gui/ui/windows/template_page.py
+++ b/src/osdag_gui/ui/windows/template_page.py
@@ -25,7 +25,7 @@ from ..components.dialogs.check_for_updates import UpdateDialog
 
 from osdag_core.Common import *
 
-from ..windows.additional_inputs import AdditionalInputs
+from .additional_inputs import AdditionalInputs
 from osdag_core.cad.common_logic import CommonDesignLogic
 from ...data.database.database_config import *
 
@@ -136,7 +136,7 @@ class CustomWindow(QWidget):
             QtCore, QtGui, QtWidgets, QtOpenGL = get_qt_modules()
 
         from OCC.Display.qtDisplay import qtViewer3d
-        from ...ui.components.custom_3dviewer import CustomViewer3d
+        from ..components.custom_3dviewer import CustomViewer3d
 
         self.cad_widget = CustomViewer3d(self)
         self.cad_widget.setFocusPolicy(Qt.StrongFocus)

--- a/src/osdag_gui/ui/windows/template_page.py
+++ b/src/osdag_gui/ui/windows/template_page.py
@@ -1,6 +1,6 @@
 import sys, os, yaml, time
 import osdag_gui.resources.resources_rc
-from osdag_gui.OS_safety_protocols import get_cleanup_coordinator
+from ...OS_safety_protocols import get_cleanup_coordinator
 from PySide6.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QHBoxLayout, 
     QPushButton, QFileDialog,  QCheckBox, QComboBox, QLineEdit,
@@ -20,7 +20,7 @@ from ..components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxT
 from ..components.dialogs.video_tutorials import TutorialsDialog
 from ..components.dialogs.ask_questions import AskQuestions
 from ..components.dialogs.about_osdag import AboutOsdagDialog
-from osdag_gui.common_functions import design_examples
+from ...common_functions import design_examples
 from ..components.dialogs.check_for_updates import UpdateDialog
 
 from osdag_core.Common import *
@@ -29,7 +29,7 @@ from ..windows.additional_inputs import AdditionalInputs
 from osdag_core.cad.common_logic import CommonDesignLogic
 from ...data.database.database_config import *
 
-from osdag_gui.__config__ import CAD_BACKEND
+from ...__config__ import CAD_BACKEND
 
 from ..components.custom_3dviewer import NavMode
 
@@ -136,7 +136,7 @@ class CustomWindow(QWidget):
             QtCore, QtGui, QtWidgets, QtOpenGL = get_qt_modules()
 
         from OCC.Display.qtDisplay import qtViewer3d
-        from osdag_gui.ui.components.custom_3dviewer import CustomViewer3d
+        from ...ui.components.custom_3dviewer import CustomViewer3d
 
         self.cad_widget = CustomViewer3d(self)
         self.cad_widget.setFocusPolicy(Qt.StrongFocus)
@@ -1458,7 +1458,7 @@ class CustomWindow(QWidget):
     # This opens loading widget and execute Design
     def start_thread(self, data):
         # Use safety module for multiprocessing (already initialized at startup)
-        from osdag_gui.OS_safety_protocols import ensure_safe_startup
+        from ...OS_safety_protocols import ensure_safe_startup
         ensure_safe_startup()
         
         # Ensure CAD widget is visible

--- a/src/osdag_gui/ui/windows/template_page.py
+++ b/src/osdag_gui/ui/windows/template_page.py
@@ -1,5 +1,5 @@
 import sys, os, yaml, time
-import osdag_gui.resources.resources_rc
+from ...resources import resources_rc
 from ...OS_safety_protocols import get_cleanup_coordinator
 from PySide6.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QHBoxLayout, 

--- a/src/osdag_gui/ui/windows/template_page.py
+++ b/src/osdag_gui/ui/windows/template_page.py
@@ -9,29 +9,29 @@ from PySide6.QtWidgets import (
 from PySide6.QtSvgWidgets import QSvgWidget
 from PySide6.QtCore import Qt, QPoint, QRect, QPropertyAnimation, QEvent, Signal, QTimer
 from PySide6.QtGui import QKeySequence, QAction, QColor, QBrush, QPixmap, QCursor
-from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
+from ..utils.custom_cursors import pointing_hand_cursor
 
-from osdag_gui.ui.components.floating_nav_bar import SidebarWidget
-from osdag_gui.ui.components.docks.input_dock import InputDock
-from osdag_gui.ui.components.docks.output_dock import OutputDock
-from osdag_gui.ui.components.docks.log_dock import LogDock
-from osdag_gui.ui.components.dialogs.loading_popup import LoadingDialogManager
-from osdag_gui.ui.components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
-from osdag_gui.ui.components.dialogs.video_tutorials import TutorialsDialog
-from osdag_gui.ui.components.dialogs.ask_questions import AskQuestions
-from osdag_gui.ui.components.dialogs.about_osdag import AboutOsdagDialog
+from ..components.floating_nav_bar import SidebarWidget
+from ..components.docks.input_dock import InputDock
+from ..components.docks.output_dock import OutputDock
+from ..components.docks.log_dock import LogDock
+from ..components.dialogs.loading_popup import LoadingDialogManager
+from ..components.dialogs.custom_messagebox import CustomMessageBox, MessageBoxType
+from ..components.dialogs.video_tutorials import TutorialsDialog
+from ..components.dialogs.ask_questions import AskQuestions
+from ..components.dialogs.about_osdag import AboutOsdagDialog
 from osdag_gui.common_functions import design_examples
-from osdag_gui.ui.components.dialogs.check_for_updates import UpdateDialog
+from ..components.dialogs.check_for_updates import UpdateDialog
 
 from osdag_core.Common import *
 
-from osdag_gui.ui.windows.additional_inputs import AdditionalInputs
+from ..windows.additional_inputs import AdditionalInputs
 from osdag_core.cad.common_logic import CommonDesignLogic
-from osdag_gui.data.database.database_config import *
+from ...data.database.database_config import *
 
 from osdag_gui.__config__ import CAD_BACKEND
 
-from osdag_gui.ui.components.custom_3dviewer import NavMode
+from ..components.custom_3dviewer import NavMode
 
 
 class CustomWindow(QWidget):


### PR DESCRIPTION
## Refactor: Convert absolute imports to relative in `osdag_gui`

Related: #476 (review comment by @AjinkyaDahale, suggested by @parthckaria)

---

### What this PR does

Converts all `from osdag_gui.*` absolute imports to relative imports across the entire `osdag_gui` package.

**Before:**
```python
from osdag_gui.ui.components.docks.input_dock import InputDock
from osdag_gui.ui.utils.custom_cursors import pointing_hand_cursor
```

**After:**
```python
from ..components.docks.input_dock import InputDock
from ..utils.custom_cursors import pointing_hand_cursor
```

---

### Scope

- Files modified: 50
- Lines changed: 151

---

### What was NOT changed

- No logic, formatting, or blank lines modified
- External package imports (`PySide6`, `osdag_core`, `numpy`, etc.) unchanged
- Files with zero `osdag_gui` imports are byte-for-byte identical

---

### Verification

- ✅ No remaining `from osdag_gui.` imports inside `src/osdag_gui/`
- ✅ Dot depth correct for every file's directory level
- ✅ App runs after refactor

---

cc @AjinkyaDahale @parthckaria